### PR TITLE
Remove unwanted tools from document show view.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -88,6 +88,14 @@ class CatalogController < ApplicationController
     # partials for show view
     config.show.partials = [:show_header, :show, :show_license, :show_children]
 
+    # deactivate certain tools
+    config.show.document_actions.delete(:email)
+    config.show.document_actions.delete(:sms)
+    config.show.document_actions.delete(:citation)
+    config.show.document_actions.delete(:refworks)
+    config.show.document_actions.delete(:endnote)
+    config.show.document_actions.delete(:librarian_view)
+
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     config.add_show_field solr_name(:title, :stored_searchable), separator: '; ', label: 'Title'

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,0 +1,12 @@
+<% if render_bookmarks_control? %>
+	<%= render :partial => 'show_tools' %>
+<% end %>
+
+<% unless @document.more_like_this.empty? %>
+  <div class="panel panel-default">
+    <div class="panel-heading">More Like This</div>
+    <div class="panel-body">
+      <%= render :collection => @document.more_like_this, :partial => 'show_more_like_this', :as => :document %>
+    </div>
+  </div>
+<% end %>

--- a/lib/ddr/public/version.rb
+++ b/lib/ddr/public/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Public
-    VERSION = "1.0.2"
+    VERSION = "1.0.3"
   end
 end


### PR DESCRIPTION
Removes all show tools added by BL in Blacklight::Catalog::ComponentConfiguration
except for bookmarks.
Suppresses display of Tools partial unless bookmarks tool is applicable for that
particular show view (e.g., must have logged in user).