### PR TITLE
Sort entries in Collection facet by collection title.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development, :test do
   gem 'factory_girl_rails', '~> 4.4'
   gem 'launchy'
   gem 'database_cleaner'
+  gem 'orderly'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,7 @@ GEM
       rack (~> 1.0)
     omniauth-shibboleth (1.2.0)
       omniauth (>= 1.0.0)
+    orderly (0.0.2)
     orm_adapter (0.5.0)
     rack (1.5.2)
     rack-protection (1.5.3)
@@ -420,6 +421,7 @@ DEPENDENCIES
   launchy
   log4r
   mysql2
+  orderly
   rails (~> 4.1.6)
   rspec-rails (~> 3.0)
   sass-rails (~> 4.0.3)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,27 @@
 module ApplicationHelper
 
+  # Overrides corresponding method in Blacklight::FacetsHelperBehavior
+  def render_facet_limit_list(paginator, solr_field, wrapping_element=:li)
+    if solr_field == Ddr::IndexFields::IS_MEMBER_OF_COLLECTION
+      # apply custom sort for 'Collection' facet
+      items = collection_facet_sort(paginator.items)
+    else
+      items = paginator.items
+    end
+    safe_join(items.
+      map { |item| render_facet_item(solr_field, item) }.compact.
+      map { |item| content_tag(wrapping_element,item)}
+    )
+  end
+
+  # Custom sort for 'Collection' facet
+  # Sort by title of collection normalized to lower case for case-independent sorting
+  # The 'value' attribute of each 'item' in the facet is the collection URI
+  # The #collection_title method is defined in CatalogHelper and is also the view helper for the facet field
+  def collection_facet_sort(items=[])
+    items.sort { |a,b| collection_title(a.value).downcase <=> collection_title(b.value).downcase }
+  end
+
   def alert_messages
     session[:alert_messages] ||= Ddr::Alerts::Message.active.pluck(:message)
   end

--- a/lib/ddr/public/version.rb
+++ b/lib/ddr/public/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Public
-    VERSION = "1.0.4"
+    VERSION = "1.0.5"
   end
 end

--- a/spec/features/catalog/index_spec.rb
+++ b/spec/features/catalog/index_spec.rb
@@ -2,27 +2,40 @@ require 'rails_helper'
 
 RSpec.describe "catalog/index", :type => :feature do
 
-  let(:published_collection) { Collection.create(title: ["Collection A"], read_groups: ["public"]) }
-  let(:published_item) { Item.create(title: ["Item 1"]) }
+  let(:published_collection_c) { Collection.create(title: ["Collection C"], read_groups: ["public"]) }
+  let(:published_item_1) { Item.create(title: ["Item 1"]) }
+  let(:published_item_2) { Item.create(title: ["Item 2"]) }
   let(:unpublished_collection) { Collection.create(title: ["Collection B"], read_groups: ["public"]) }
-  let(:unpublished_item) { Item.create(title: ["Item 2"]) }
+  let(:unpublished_item) { Item.create(title: ["Item 3"]) }
+  let(:published_collection_a) { Collection.create(title: ["Collection A"], read_groups: ["public"]) }
+  let(:published_item_4) { Item.create(title: ["Item 4"]) }
   before do
-    published_collection.default_permissions = [ {:name=>"public", :access=>"read", :type=>"group"} ]
-    published_item.admin_policy = published_collection
-    published_collection.items << published_item
-    published_collection.save!
-    published_item.save!
-    published_collection.publish!
-    published_item.publish!
+    published_collection_c.default_permissions = [ {:name=>"public", :access=>"read", :type=>"group"} ]
+    published_item_1.admin_policy = published_collection_c
+    published_item_2.admin_policy = published_collection_c
+    published_collection_c.items << [ published_item_1, published_item_2 ]
+    published_collection_c.save!
+    published_item_1.save!
+    published_item_2.save!
+    published_collection_c.publish!
+    published_item_1.publish!
+    published_item_2.publish!
     unpublished_collection.default_permissions = [ {:name=>"public", :access=>"read", :type=>"group"} ]
     unpublished_item.admin_policy = unpublished_collection
     unpublished_collection.items << unpublished_item
     unpublished_collection.save!
     unpublished_item.save!
+    published_collection_a.default_permissions = [ {:name=>"public", :access=>"read", :type=>"group"} ]
+    published_item_4.admin_policy = published_collection_a
+    published_collection_a.items << published_item_4
+    published_collection_a.save!
+    published_item_4.save!
+    published_collection_a.publish!
+    published_item_4.publish!
   end
-  it "should display the collection facet with the published collection" do
+  it "should display the collection facet with the published collections in title order" do
     visit catalog_index_path
-    expect(page).to have_link("Collection A")
+    expect(published_collection_a.title_display).to appear_before(published_collection_c.title_display)
     expect(page).to_not have_link("Collection B")
   end
 


### PR DESCRIPTION
Override BL #render_facet_limit_list method in Blacklight::FacetsHelperBehavior and
provide custom sort for items in facet paginator if facet field is that used by
the Collection facet.