### PR TITLE
Increase max results per page from default 100 to 999.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -182,6 +182,9 @@ class CatalogController < ApplicationController
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.
     config.spell_max = 5
+
+    # Maximum number of results to show per page
+    config.max_per_page = 999
   end
 
   def include_only_published(solr_parameters, user_parameters)

--- a/lib/ddr/public/version.rb
+++ b/lib/ddr/public/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Public
-    VERSION = "1.0.6"
+    VERSION = "1.0.7"
   end
 end


### PR DESCRIPTION
Temporary fix pending implementation of pagination of children on parent
show pages.
Closes #98