### PR TITLE
PermanentIdsController show view renders "not published" template when o...

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,4 +65,8 @@ module ApplicationHelper
     end
   end
 
+  def staff_url(doc_or_obj)
+    "#{Ddr::Public.staff_app_url}id/#{doc_or_obj.permanent_id}"
+  end
+
 end

--- a/app/views/application/not_found.html.erb
+++ b/app/views/application/not_found.html.erb
@@ -1,0 +1,3 @@
+<div class="alert alert-danger" role="alert">
+  The requested resource was not found.
+</div>

--- a/app/views/application/not_published.html.erb
+++ b/app/views/application/not_published.html.erb
@@ -1,0 +1,7 @@
+<div class="alert alert-danger" role="alert">
+  We're sorry! Access to this resource is restricted to Duke University Libraries staff. For assistance, please contact <%= link_to "repository-help@duke.edu", "mailto:repository-help@duke.edu" %>.
+<div>
+
+<p>
+  Authorized staff may access the resource at <%= link_to staff_url(@document), staff_url(@document) %>.
+</p>

--- a/lib/ddr/public/configurable.rb
+++ b/lib/ddr/public/configurable.rb
@@ -11,6 +11,10 @@ module Ddr
         # Help URL
         mattr_accessor :help_url
 
+        mattr_accessor :staff_app_url do
+          ENV["STAFF_APP_URL"] || "https://ddr.lib.duke.edu/"
+        end
+
       end
 
       module ClassMethods

--- a/spec/controllers/permanent_ids_controller_spec.rb
+++ b/spec/controllers/permanent_ids_controller_spec.rb
@@ -2,10 +2,29 @@ require "rails_helper"
 
 RSpec.describe PermanentIdsController do
   describe "#show" do
-    let!(:obj) { Item.create(permanent_id: "ark:/99999/fk4zzzzz") }
-    it "should redirect to the catalog show view" do
-      get :show, permanent_id: "ark:/99999/fk4zzzzz"
-      expect(response).to redirect_to(catalog_path(obj))
+    describe "when the object does not exist" do
+      it "should render a 404 not found response" do
+        get :show, permanent_id: "ark:/99999/fkyyyyy"
+        expect(response.response_code).to eq(404)
+      end
+    end
+    describe "when the object exists" do
+      let(:obj) { Item.new(permanent_id: "ark:/99999/fk4zzzzz") }
+      describe "when the object is not published" do
+        before { obj.save! }
+        it "should render the not_published template" do
+          get :show, permanent_id: "ark:/99999/fk4zzzzz"
+          expect(response.response_code).to eq(403)
+          expect(response).to render_template(:not_published)
+        end
+      end
+      describe "when the object is published" do
+        before { obj.publish! }
+        it "should redirect to the catalog show view" do
+          get :show, permanent_id: "ark:/99999/fk4zzzzz"
+          expect(response).to redirect_to(catalog_path(obj))
+        end
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,7 +72,9 @@ RSpec.configure do |config|
     Ddr::Models.external_file_store = Dir.mktmpdir
   end
   config.after(:suite) do
-    FileUtils.remove_entry_secure Ddr::Models.external_file_store
+    if Dir.exists?(Ddr::Models.external_file_store)
+      FileUtils.remove_entry_secure Ddr::Models.external_file_store
+    end
   end
   config.after(:each) { ActiveFedora::Base.destroy_all }
   config.after(:each, type: :feature) { Warden.test_reset! }

--- a/spec/views/application/not_published.html.erb_spec.rb
+++ b/spec/views/application/not_published.html.erb_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "application/not_published.html.erb" do
+  let(:permanent_id) { "ark:/99999/fk4zzzzz" }
+  let(:document) { double(permanent_id: permanent_id) }
+  it "displays a link to the staff view" do
+    assign(:document, document)
+    render
+    expect(rendered).to have_link("#{Ddr::Public.staff_app_url}id/#{permanent_id}")
+  end
+end


### PR DESCRIPTION
...bject is not published

Fixes #102
Also renders "not found" template and 404 status when object does not exist
(instead of raising uncaught exception).