### PR TITLE
migrate identifier to local_id

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -31,16 +31,14 @@ module BlacklightHelper
 
   def filter_values_for_document(doc_or_obj)
     document_type = doc_or_obj[Ddr::IndexFields::ACTIVE_FEDORA_MODEL].downcase.to_sym
-
+    local_id = ""
+    admin_set = ""
     if document_type == :collection
-      local_id = doc_or_obj.identifier.first
+      local_id = doc_or_obj.local_id if doc_or_obj.local_id
       admin_set = doc_or_obj[Ddr::IndexFields::ADMIN_SET]
     elsif document_type == :item or document_type == :component
       local_id = local_id_from_uri(doc_or_obj['is_governed_by_ssim'])
       admin_set = admin_set_from_uri(doc_or_obj['is_governed_by_ssim'])
-    else
-      local_id = ""
-      admin_set = ""
     end
     [local_id, admin_set]
   end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -98,8 +98,8 @@ module CatalogHelper
 
   def local_id_from_uri uri
     document = document_from_uri(uri.first)
-    unless document.identifier.blank?
-      document.identifier.first
+    unless document.local_id.blank?
+      document.local_id
     end
   end
 


### PR DESCRIPTION
Migrates use of identifier to local_id in picking url for documents. Also accommodates case where local_id is not present.