### PR TITLE
use older version of blacklight_range_limit gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'font-awesome-sass'
 gem 'openseadragon', '~> 0.2.0'
 gem 'blacklight-gallery'
 gem 'rubyzip', '~> 1.1.7'
-gem 'blacklight_range_limit'
+gem 'blacklight_range_limit', '5.0.4'
 
 
 gem 'sdoc', '~> 0.4.0', group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       bootstrap-sass (~> 3.0)
       openseadragon (>= 0.2.0)
       rails
-    blacklight_range_limit (5.1.0)
+    blacklight_range_limit (5.0.4)
       blacklight (>= 5.0.0.pre4, < 6)
       jquery-rails
       rails (>= 3.0, < 5.0)
@@ -421,7 +421,7 @@ PLATFORMS
 
 DEPENDENCIES
   blacklight-gallery
-  blacklight_range_limit
+  blacklight_range_limit (= 5.0.4)
   bootstrap-sass (~> 3.3.4)
   bootswatch-rails
   capybara (~> 2.0)


### PR DESCRIPTION
This fixes a bug where the following AJAX request was failing when trying to load the range limit facet: http://localhost:3000/dc/wdukesons/range_limit?range_end=1890&range_field=year_facet_iim&range_start=1886&search_field=dummy_range

The latest version of blacklight_range_limit uses Blacklight.default_index.connection.get while our version of blacklight uses Blacklight.solr.get. This was causing a no method error.

https://github.com/projectblacklight/blacklight_range_limit/commit/50100dc19f9f68919421383cc17708ce3657bbff#diff-a7da87e4125dfb8355fafe37687e74deL46