### PR TITLE
update ddr-models to 2.1.0.rc2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '~> 4.1.6'
 gem 'hydra-head', '~> 7.2.0'
 gem 'ddr-alerts', '~> 1.0.0'
 gem 'devise' # must be explicitly required
-gem 'ddr-models', :git => 'https://github.com/duke-libraries/ddr-models.git', :ref => 'cc493479e84893ee1683d43be2ece0b3591b175a'
+gem 'ddr-models', '2.1.0.rc2'
 
 gem 'log4r'
 gem 'bootstrap-sass', '~> 3.3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,3 @@
-GIT
-  remote: https://github.com/duke-libraries/ddr-models.git
-  revision: cc493479e84893ee1683d43be2ece0b3591b175a
-  ref: cc493479e84893ee1683d43be2ece0b3591b175a
-  specs:
-    ddr-models (2.0.1.post)
-      active-fedora (~> 7.0)
-      cancancan (~> 1.12)
-      devise (~> 3.4)
-      ezid-client (~> 1.1, >= 1.1.1)
-      grouper-rest-client
-      hydra-core (~> 7.2)
-      hydra-validations (~> 0.5)
-      net-ldap (~> 0.11)
-      omniauth-shibboleth (~> 1.2.0)
-      rails (~> 4.1.6)
-      rdf-vocab (~> 0.8)
-      resque (~> 1.25)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -111,6 +92,24 @@ GEM
     database_cleaner (1.4.0)
     ddr-alerts (1.0.0)
       rails (~> 4.1.6)
+    ddr-antivirus (2.0.0)
+    ddr-aux-client (1.2.1)
+      hashie (~> 3.4)
+    ddr-models (2.1.0.rc2)
+      active-fedora (~> 7.0)
+      cancancan (~> 1.12)
+      ddr-antivirus (= 2.0.0)
+      ddr-aux-client (~> 1.2, >= 1.2.1)
+      devise (~> 3.4)
+      ezid-client (~> 1.1, >= 1.1.1)
+      grouper-rest-client
+      hydra-core (~> 7.2)
+      hydra-validations (~> 0.5)
+      net-ldap (~> 0.11)
+      omniauth-shibboleth (~> 1.2.0)
+      rails (~> 4.1.6)
+      rdf-vocab (~> 0.8)
+      resque (~> 1.25)
     deprecation (0.1.0)
       activesupport
     devise (3.4.1)
@@ -307,7 +306,7 @@ GEM
     rdf-turtle (1.1.5)
       ebnf (~> 0.3, >= 0.3.6)
       rdf (~> 1.1, >= 1.1.4)
-    rdf-vocab (0.8.4)
+    rdf-vocab (0.8.5)
       rdf (~> 1.1, >= 1.1.10)
     rdf-xsd (1.1.2)
       rdf (~> 1.1)
@@ -435,7 +434,7 @@ DEPENDENCIES
   coffee-rails (~> 4.0.0)
   database_cleaner
   ddr-alerts (~> 1.0.0)
-  ddr-models!
+  ddr-models (= 2.1.0.rc2)
   devise
   factory_girl_rails (~> 4.4)
   fastimage

--- a/app/controllers/blake_controller.rb
+++ b/app/controllers/blake_controller.rb
@@ -8,7 +8,7 @@ class BlakeController < DigitalCollectionsController
 
   configure_blacklight do |config|
     config.facet_fields.clear
-    config.add_facet_field Ddr::IndexFields::TYPE_FACET.to_s, label: "Type", collapse: false, sort: 'index'
+    config.add_facet_field Ddr::Index::Fields::TYPE_FACET.to_s, label: "Type", collapse: false, sort: 'index'
   end
 
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -37,9 +37,9 @@ class CatalogController < ApplicationController
     }
 
     # solr field configuration for search results/index views
-    config.index.title_field = Ddr::IndexFields::TITLE.to_s
-    config.index.active_fedora_model_field = Ddr::IndexFields::ACTIVE_FEDORA_MODEL.to_s
-    config.index.display_type_field = Ddr::IndexFields::DISPLAY_FORMAT.to_s
+    config.index.title_field = Ddr::Index::Fields::TITLE.to_s
+    config.index.active_fedora_model_field = Ddr::Index::Fields::ACTIVE_FEDORA_MODEL.to_s
+    config.index.display_type_field = Ddr::Index::Fields::DISPLAY_FORMAT.to_s
 
     config.index.thumbnail_method = :thumbnail_image_tag
 
@@ -69,8 +69,8 @@ class CatalogController < ApplicationController
     # config.add_facet_field solr_name('lc1_letter', :facetable), :label => 'Call Number'
     # config.add_facet_field solr_name('subject_geo', :facetable), :label => 'Region'
     # config.add_facet_field solr_name('subject_era', :facetable), :label => 'Era'
-    config.add_facet_field Ddr::IndexFields::ADMIN_SET_FACET.to_s, label: 'Collection Group', helper_method: 'admin_set_full_name', limit: 9999
-    config.add_facet_field Ddr::IndexFields::COLLECTION_FACET.to_s, label: 'Collection', helper_method: 'collection_title', limit: 9999
+    config.add_facet_field Ddr::Index::Fields::ADMIN_SET_FACET.to_s, label: 'Collection Group', helper_method: 'admin_set_full_name', limit: 9999
+    config.add_facet_field Ddr::Index::Fields::COLLECTION_FACET.to_s, label: 'Collection', helper_method: 'collection_title', limit: 9999
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -84,18 +84,18 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name(:creator, :stored_searchable), separator: '; ', label: 'Creator'
     config.add_index_field solr_name(:date, :stored_searchable), separator: '; ', label: 'Date'
     config.add_index_field solr_name(:type, :stored_searchable), separator: '; ', label:'Type'
-    config.add_index_field Ddr::IndexFields::PERMANENT_URL.to_s, helper_method: 'permalink', label: 'Permalink'
-    config.add_index_field Ddr::IndexFields::MEDIA_TYPE.to_s, helper_method: 'file_info', label: 'File'
-    config.add_index_field Ddr::IndexFields::IS_PART_OF.to_s, helper_method: 'descendant_of', label: 'Part of'
-    config.add_index_field Ddr::IndexFields::IS_MEMBER_OF_COLLECTION.to_s, helper_method: 'descendant_of', label: 'Collection'
-    config.add_index_field Ddr::IndexFields::COLLECTION_URI.to_s, helper_method: 'descendant_of', label: 'Collection'
+    config.add_index_field Ddr::Index::Fields::PERMANENT_URL.to_s, helper_method: 'permalink', label: 'Permalink'
+    config.add_index_field Ddr::Index::Fields::MEDIA_TYPE.to_s, helper_method: 'file_info', label: 'File'
+    config.add_index_field Ddr::Index::Fields::IS_PART_OF.to_s, helper_method: 'descendant_of', label: 'Part of'
+    config.add_index_field Ddr::Index::Fields::IS_MEMBER_OF_COLLECTION.to_s, helper_method: 'descendant_of', label: 'Collection'
+    config.add_index_field Ddr::Index::Fields::COLLECTION_URI.to_s, helper_method: 'descendant_of', label: 'Collection'
 
     config.default_document_solr_params = {
-      fq: ["#{Ddr::IndexFields::WORKFLOW_STATE}:published"]
+      fq: ["#{Ddr::Index::Fields::WORKFLOW_STATE}:published"]
     }
 
     # partials for show view
-    config.show.partials = [:show_header, :show, :show_license, :show_children]
+    config.show.partials = [:show_header, :show, :show_children]
 
     # deactivate certain tools
     config.show.document_actions.delete(:email)
@@ -108,8 +108,8 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     config.add_show_field solr_name(:title, :stored_searchable), separator: '; ', label: 'Title'
-    config.add_show_field Ddr::IndexFields::PERMANENT_URL.to_s, helper_method: 'permalink', label: 'Permalink'
-    config.add_show_field Ddr::IndexFields::MEDIA_TYPE.to_s, helper_method: 'file_info', label: 'File'
+    config.add_show_field Ddr::Index::Fields::PERMANENT_URL.to_s, helper_method: 'permalink', label: 'Permalink'
+    config.add_show_field Ddr::Index::Fields::MEDIA_TYPE.to_s, helper_method: 'file_info', label: 'File'
     config.add_show_field solr_name(:creator, :stored_searchable), separator: '; ', label: 'Creator'
     config.add_show_field solr_name(:date, :stored_searchable), separator: '; ', label: 'Date'
     config.add_show_field solr_name(:type, :stored_searchable), separator: '; ', label: 'Type'
@@ -119,9 +119,9 @@ class CatalogController < ApplicationController
     Ddr::Vocab::Vocabulary.term_names(Ddr::Vocab::DukeTerms).each do |term_name|
       config.add_show_field solr_name(term_name, :stored_searchable), separator: '; ', label: term_name.to_s.titleize
     end
-    config.add_show_field Ddr::IndexFields::IS_PART_OF.to_s, helper_method: 'descendant_of', label: 'Part of'
-    config.add_show_field Ddr::IndexFields::IS_MEMBER_OF_COLLECTION.to_s, helper_method: 'descendant_of', label: 'Collection'
-    config.add_show_field Ddr::IndexFields::COLLECTION_URI.to_s, helper_method: 'descendant_of', label: 'Collection'
+    config.add_show_field Ddr::Index::Fields::IS_PART_OF.to_s, helper_method: 'descendant_of', label: 'Part of'
+    config.add_show_field Ddr::Index::Fields::IS_MEMBER_OF_COLLECTION.to_s, helper_method: 'descendant_of', label: 'Collection'
+    config.add_show_field Ddr::Index::Fields::COLLECTION_URI.to_s, helper_method: 'descendant_of', label: 'Collection'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
@@ -143,7 +143,7 @@ class CatalogController < ApplicationController
 
     config.add_search_field 'all_fields', :label => 'All Fields' do |field|
       field.solr_local_parameters = {
-        :qf => "id title_tesim creator_tesim subject_tesim description_tesim identifier_tesim #{Ddr::IndexFields::PERMANENT_ID}"
+        :qf => "id title_tesim creator_tesim subject_tesim description_tesim identifier_tesim #{Ddr::Index::Fields::PERMANENT_ID}"
       }
     end
 
@@ -186,7 +186,7 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     config.add_sort_field 'score desc, pub_date_dtsi desc, title_tesi asc', :label => 'relevance'
-    config.add_sort_field "#{Ddr::IndexFields::TITLE} asc", :label => 'title'
+    config.add_sort_field "#{Ddr::Index::Fields::TITLE} asc", :label => 'title'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.
@@ -198,19 +198,19 @@ class CatalogController < ApplicationController
 
   def include_only_published(solr_parameters, user_parameters)
       solr_parameters[:fq] ||= []
-      solr_parameters[:fq] << "#{Ddr::IndexFields::WORKFLOW_STATE}:published"
+      solr_parameters[:fq] << "#{Ddr::Index::Fields::WORKFLOW_STATE}:published"
   end
   
   def exclude_components(solr_parameters, user_parameters)
       solr_parameters[:fq] ||= []
-      solr_parameters[:fq] << "-#{Ddr::IndexFields::ACTIVE_FEDORA_MODEL}:Component"
+      solr_parameters[:fq] << "-#{Ddr::Index::Fields::ACTIVE_FEDORA_MODEL}:Component"
   end  
 
   def configure_blacklight_for_children
     blacklight_config.configure do |config|
       config.sort_fields.clear
-      config.add_sort_field "#{Ddr::IndexFields::TITLE} asc", label: "Title"
-      config.add_sort_field "#{Ddr::IndexFields::LOCAL_ID} asc", label: "Local ID"
+      config.add_sort_field "#{Ddr::Index::Fields::TITLE} asc", label: "Title"
+      config.add_sort_field "#{Ddr::Index::Fields::LOCAL_ID} asc", label: "Local ID"
     end
   end
 

--- a/app/controllers/concerns/ddr/public/controller/portal_controller_config.rb
+++ b/app/controllers/concerns/ddr/public/controller/portal_controller_config.rb
@@ -18,30 +18,30 @@ module Ddr
         def set_showcase_images_before_filter
           if portals_and_collections[controller_name]['showcase'] && portals_and_collections[controller_name]['showcase']['local_ids'] 
             showcase_ids = portals_and_collections[controller_name]['showcase']['local_ids']
-            response, @collection_showcase_document_list = get_search_results({:q => construct_solr_parameter_value({:solr_field => Ddr::IndexFields::LOCAL_ID, :boolean_operator => "OR", :values => showcase_ids})}, :rows => 40)
+            response, @collection_showcase_document_list = get_search_results({:q => construct_solr_parameter_value({:solr_field => Ddr::Index::Fields::LOCAL_ID, :boolean_operator => "OR", :values => showcase_ids})}, :rows => 40)
           end
         end
         
         def set_highlight_images_before_filter
           if portals_and_collections[controller_name]['highlight'] && portals_and_collections[controller_name]['highlight']['local_ids']
             highlight_ids = portals_and_collections[controller_name]['highlight']['local_ids']
-            response, @collection_highlight_document_list = get_search_results({:q => construct_solr_parameter_value({:solr_field => Ddr::IndexFields::LOCAL_ID, :boolean_operator => "OR", :values => highlight_ids})}, :rows => 40)
+            response, @collection_highlight_document_list = get_search_results({:q => construct_solr_parameter_value({:solr_field => Ddr::Index::Fields::LOCAL_ID, :boolean_operator => "OR", :values => highlight_ids})}, :rows => 40)
           end
         end        
 
         def include_only_specified_records(solr_parameters, user_parameters)
           if @parent_collections_uris
             solr_parameters[:fq] ||= []
-            solr_parameters[:fq] << construct_solr_parameter_value({:solr_field => Ddr::IndexFields::IS_GOVERNED_BY, :boolean_operator => "OR", :values => @parent_collections_uris})
+            solr_parameters[:fq] << construct_solr_parameter_value({:solr_field => Ddr::Index::Fields::IS_GOVERNED_BY, :boolean_operator => "OR", :values => @parent_collections_uris})
           end
         end
 
         def get_document_uris_from_admin_sets_and_local_ids
           if portals_and_collections[controller_name]['include']['admin_sets']
-            get_document_uris({:field => Ddr::IndexFields::ADMIN_SET, :config_values => portals_and_collections[controller_name]['include']['admin_sets']})
+            get_document_uris({:field => Ddr::Index::Fields::ADMIN_SET, :config_values => portals_and_collections[controller_name]['include']['admin_sets']})
           end
           if portals_and_collections[controller_name]['include']['local_ids']
-            get_document_uris({:field => Ddr::IndexFields::IDENTIFIER_ALL, :config_values => portals_and_collections[controller_name]['include']['local_ids']})
+            get_document_uris({:field => Ddr::Index::Fields::IDENTIFIER_ALL, :config_values => portals_and_collections[controller_name]['include']['local_ids']})
           end
         end
 

--- a/app/controllers/digital_collections_controller.rb
+++ b/app/controllers/digital_collections_controller.rb
@@ -9,7 +9,7 @@ class DigitalCollectionsController < CatalogController
 
   configure_blacklight do |config|
     config.facet_fields.clear
-    config.add_facet_field Ddr::IndexFields::COLLECTION_FACET.to_s, label: 'Collection', helper_method: 'collection_title', limit: 9999, collapse: false 
+    config.add_facet_field Ddr::Index::Fields::COLLECTION_FACET.to_s, label: 'Collection', helper_method: 'collection_title', limit: 9999, collapse: false 
     config.view.gallery.default = true
 
   end

--- a/app/controllers/nescent_controller.rb
+++ b/app/controllers/nescent_controller.rb
@@ -9,7 +9,7 @@ class NescentController < CatalogController
 
   configure_blacklight do |config|
     config.facet_fields.clear
-    config.add_facet_field Ddr::IndexFields::COLLECTION_FACET.to_s, label: 'Collection', helper_method: 'collection_title', limit: 9999, collapse: false 
+    config.add_facet_field Ddr::Index::Fields::COLLECTION_FACET.to_s, label: 'Collection', helper_method: 'collection_title', limit: 9999, collapse: false 
   end
 
 end

--- a/app/controllers/permanent_ids_controller.rb
+++ b/app/controllers/permanent_ids_controller.rb
@@ -4,7 +4,7 @@ class PermanentIdsController < ApplicationController
 
   def show
     permanent_id = params.require(:permanent_id)
-    response = query_solr(q: "#{Ddr::IndexFields::PERMANENT_ID}:\"#{permanent_id}\"", rows: 1)
+    response = query_solr(q: "#{Ddr::Index::Fields::PERMANENT_ID}:\"#{permanent_id}\"", rows: 1)
     if response.total == 0
       render file: "#{Rails.root}/public/404", layout: false, status: 404
     else

--- a/app/controllers/wdukesons_controller.rb
+++ b/app/controllers/wdukesons_controller.rb
@@ -8,16 +8,16 @@ class WdukesonsController < DigitalCollectionsController
 
   configure_blacklight do |config|
     config.facet_fields.clear
-    config.add_facet_field Ddr::IndexFields::TYPE_FACET.to_s, label: "Type", collapse: false, limit: 5
-    config.add_facet_field Ddr::IndexFields::YEAR_FACET.to_s, label: 'Year', collapse: false, limit: 9999, :range => {
+    config.add_facet_field Ddr::Index::Fields::TYPE_FACET.to_s, label: "Type", collapse: false, limit: 5
+    config.add_facet_field Ddr::Index::Fields::YEAR_FACET.to_s, label: 'Year', collapse: false, limit: 9999, :range => {
       :num_segments => 6,
       :assumed_boundaries => [1889, 1935],
       :segments => true    
     }    
-    config.add_facet_field Ddr::IndexFields::SERIES_FACET.to_s, label: "Series", limit: 5
-    config.add_facet_field Ddr::IndexFields::PUBLISHER_FACET.to_s, label: "Publisher", limit: 5
-    config.add_facet_field Ddr::IndexFields::SPATIAL_FACET.to_s, label: "Location", limit: 5
-    config.add_facet_field Ddr::IndexFields::BOX_NUMBER_FACET.to_s, sort: 'index', label: "Box Number", limit: 5
+    config.add_facet_field Ddr::Index::Fields::SERIES_FACET.to_s, label: "Series", limit: 5
+    config.add_facet_field Ddr::Index::Fields::PUBLISHER_FACET.to_s, label: "Publisher", limit: 5
+    config.add_facet_field Ddr::Index::Fields::SPATIAL_FACET.to_s, label: "Location", limit: 5
+    config.add_facet_field Ddr::Index::Fields::BOX_NUMBER_FACET.to_s, sort: 'index', label: "Box Number", limit: 5
   end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,10 +3,10 @@ module ApplicationHelper
   # Overrides corresponding method in Blacklight::FacetsHelperBehavior
   def render_facet_limit_list(paginator, solr_field, wrapping_element=:li)
     case solr_field
-    when Ddr::IndexFields::ADMIN_SET_FACET
+    when Ddr::Index::Fields::ADMIN_SET_FACET
       # apply custom sort for 'admin set' facet
       items = admin_set_facet_sort(paginator.items)
-    when Ddr::IndexFields::COLLECTION_FACET
+    when Ddr::Index::Fields::COLLECTION_FACET
       # apply custom sort for 'Collection' facet
       items = collection_facet_sort(paginator.items)
     else

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -14,7 +14,7 @@ module BlacklightHelper
   def document_or_object_url(doc_or_obj)
     controllers_and_actions ||= portal_controllers_and_actions()
 
-    document_type = doc_or_obj[Ddr::IndexFields::ACTIVE_FEDORA_MODEL].downcase.to_sym
+    document_type = doc_or_obj[Ddr::Index::Fields::ACTIVE_FEDORA_MODEL].downcase.to_sym
 
     local_id, admin_set = filter_values_for_document(doc_or_obj)
 
@@ -30,12 +30,12 @@ module BlacklightHelper
   end
 
   def filter_values_for_document(doc_or_obj)
-    document_type = doc_or_obj[Ddr::IndexFields::ACTIVE_FEDORA_MODEL].downcase.to_sym
+    document_type = doc_or_obj[Ddr::Index::Fields::ACTIVE_FEDORA_MODEL].downcase.to_sym
     local_id = ""
     admin_set = ""
     if document_type == :collection
       local_id = doc_or_obj.local_id if doc_or_obj.local_id
-      admin_set = doc_or_obj[Ddr::IndexFields::ADMIN_SET]
+      admin_set = doc_or_obj[Ddr::Index::Fields::ADMIN_SET]
     elsif document_type == :item or document_type == :component
       local_id = local_id_from_uri(doc_or_obj['is_governed_by_ssim'])
       admin_set = admin_set_from_uri(doc_or_obj['is_governed_by_ssim'])

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -52,7 +52,7 @@ module CatalogHelper
     configure_blacklight_for_children
     relationship ||= find_relationship(document)
 
-    query = ActiveFedora::SolrService.construct_query_for_rel([[relationship, document[Ddr::IndexFields::INTERNAL_URI]]])
+    query = ActiveFedora::SolrService.construct_query_for_rel([[relationship, document[Ddr::Index::Fields::INTERNAL_URI]]])
     response, document_list = get_search_results(params.merge(rows: 99999), {q: query}) # allow params
 
     return response, document_list
@@ -109,8 +109,8 @@ module CatalogHelper
 
   def admin_set_from_uri uri
     document = document_from_uri(uri.first)
-    unless document[Ddr::IndexFields::ADMIN_SET].blank?
-      document[Ddr::IndexFields::ADMIN_SET]
+    unless document[Ddr::Index::Fields::ADMIN_SET].blank?
+      document[Ddr::Index::Fields::ADMIN_SET]
     end
   end    
 
@@ -144,18 +144,6 @@ module CatalogHelper
     end
   end
 
-
-  # View helper
-  def license_title effective_license
-    if effective_license[:title].blank?
-      effective_license[:title] = t("ddr.public.license_title")
-    end
-    if effective_license[:url].blank?
-      link_to effective_license[:title], copyright_path
-    else
-      link_to effective_license[:title], effective_license[:url]
-    end
-  end
 
   def find_collection_results response
     if response.facet_counts['facet_fields'].has_key?('collection_facet_sim')

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -22,7 +22,7 @@ class SolrDocument
   use_extension( Blacklight::Solr::Document::DublinCore)    
 
   def published?
-    get(Ddr::IndexFields::WORKFLOW_STATE) == "published"
+    get(Ddr::Index::Fields::WORKFLOW_STATE) == "published"
   end
 
   def abstract

--- a/app/views/catalog/_show_finding_aid.html.erb
+++ b/app/views/catalog/_show_finding_aid.html.erb
@@ -1,0 +1,5 @@
+<% unless document.finding_aid.blank? %>
+  <div class="text-muted text-uppercase small strong">Finding Aid</div>
+  <p><%= link_to document.finding_aid.title, document.finding_aid.url %><p>
+  <hr />
+<% end %>

--- a/app/views/catalog/_show_license_default.html.erb
+++ b/app/views/catalog/_show_license_default.html.erb
@@ -1,4 +1,2 @@
-<p><%= license_title(document.effective_license) %></p>
-<% unless document.effective_license[:description].blank? %>
-  <p class="text-muted small"><%= truncate(document.effective_license[:description], :length => 125, :separator => ' ') %></p>
-<% end %>
+<div class="text-muted text-uppercase small strong">Copyright &amp; Use</div>
+<p><%= link_to document.effective_license.title, document.effective_license.url %><p>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -13,6 +13,9 @@
       <%= render partial: 'show_collection_context', locals: { document: @collection_document } %>
     <% end %>
     <hr/>
+  <div class="finding_aid">
+    <%= render partial: 'show_finding_aid', locals: { document: @document } %>
+  </div>
   <div class="license">
     <%= render partial: 'show_license_default', locals: { document: @document } %>
   </div>

--- a/app/views/digital_collections/index.html.erb
+++ b/app/views/digital_collections/index.html.erb
@@ -17,6 +17,7 @@
     <% if has_search_parameters? %>
       <%= render partial: 'show_collection_context', locals: { document: @collection_document } %> 
     <% end %>
+    <%= render partial: 'show_finding_aid', locals: { document: @collection_document } %>
     <%= render partial: 'show_license_default', locals: { document: @collection_document } %>
   <% end %>
   <%= render 'search_sidebar' %>

--- a/spec/controllers/permanent_ids_controller_spec.rb
+++ b/spec/controllers/permanent_ids_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PermanentIdsController do
 
   describe "#show" do
     let!(:permanent_id) { "ark:/99999/fk4yyyyy" }
-    let!(:query_params) { {q: "#{Ddr::IndexFields::PERMANENT_ID}:\"#{permanent_id}\"", rows: 1} }
+    let!(:query_params) { {q: "#{Ddr::Index::Fields::PERMANENT_ID}:\"#{permanent_id}\"", rows: 1} }
 
     describe "when the object does not exist" do
       before do

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CatalogHelper do
             'active_fedora_model_ssi'=>'Component',
             'content_size_human_ssim'=>content_size,
             'workflow_state_ssi'=>'published',
-            Ddr::IndexFields::ACCESS_ROLE=>"{}",
+            Ddr::Index::Fields::ACCESS_ROLE=>"{}",
             'object_profile_ssm'=>['{"datastreams":{"content":{"dsLabel":"image10.tif","dsVersionID":"content.0","dsCreateDate":"2014-10-22T17:30:02Z","dsState":"A","dsMIME":"image/tiff","dsFormatURI":null,"dsControlGroup":"M","dsSize":69742260,"dsVersionable":true,"dsInfoType":null,"dsLocation":"changeme:10+content+content.0","dsLocationType":"INTERNAL_ID","dsChecksumType":"SHA-256","dsChecksum":"b9eb20b6fb4a27d6bf478bdefb25538bea95740bdf48471ec360d25af622a911"}}}']
             ) }
 
@@ -90,30 +90,6 @@ RSpec.describe CatalogHelper do
       end
       it "should not return a title nor a link" do
         expect(helper.research_help_title(research_help)).to be_nil
-      end
-    end
-  end
-
-  describe "#license_title" do
-    let(:effective_license) do 
-      {
-        :title => "License Title", 
-        :url => "http://copyrighturl"
-      }
-    end
-    context "item has both a license title and url" do
-      it "should return a link to the license information" do
-        expect(helper.license_title(effective_license)).to include (link_to(effective_license[:title], effective_license[:url]))
-      end
-    end
-    context "item has a url to a license but not a title" do
-      it "should return the default title as a link" do
-        expect(helper.license_title({:url => "http://copyrighturl"})).to include (link_to("Copyright & Use", "http://copyrighturl"))
-      end
-    end
-    context "item does not have a license url" do
-      it "should return the title as a link to a default copyright page" do
-        expect(helper.license_title({:url => nil, :title => "Copyright"})).to include (link_to("Copyright", copyright_path))
       end
     end
   end


### PR DESCRIPTION
This update to ddr-models 2.1.0.rc2 includes changes to the license information and the addition of finding aid information. You will need to add a license to each collection to avoid errors. If you add a finding aid identifier to the administrative metadata for collections and/or items then a link to the associated finding aid will display in the interface.