### PR TITLE
Hotfixes for range filter historgram, ssl error, and thumbnail helper; closes #198

### DIFF
--- a/app/assets/stylesheets/ddr.css.scss
+++ b/app/assets/stylesheets/ddr.css.scss
@@ -356,6 +356,9 @@ a.showcase-item-wrap, a.highlight-item-wrap {
     & input.range_begin, input.range_end {
         font-size: 15px;
     }
+    & .missing {
+      display: none;
+    }
   }
 }
 

--- a/app/controllers/wdukesons_controller.rb
+++ b/app/controllers/wdukesons_controller.rb
@@ -11,9 +11,7 @@ class WdukesonsController < DigitalCollectionsController
     config.add_facet_field Ddr::Index::Fields::ACTIVE_FEDORA_MODEL.to_s, label: "Browse", show: false
     config.add_facet_field Ddr::Index::Fields::SERIES_FACET.to_s, label: "Card Series", collapse: false, limit: 5
     config.add_facet_field Ddr::Index::Fields::YEAR_FACET.to_s, label: 'Year', collapse: false, limit: 9999, :range => {
-      :num_segments => 6,
-      :assumed_boundaries => [1889, 1935],
-      :segments => true    
+      :segments => false    
     }    
     config.add_facet_field Ddr::Index::Fields::TYPE_FACET.to_s, label: "Type", limit: 5    
     config.add_facet_field Ddr::Index::Fields::PUBLISHER_FACET.to_s, label: "Publisher", limit: 5

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -199,12 +199,9 @@ module ApplicationHelper
   def image_component_aspectratio(document)
   # Get the width / height ratio of the multi-res component's image  
     url = iiif_image_info_path(document.multires_image_file_path)
-    imagedata = JSON.load(open(url))
+    imagedata = JSON.load(open(url, { ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE }))
     aspectratio = (imagedata['width'].to_f/imagedata['height'].to_f)    
   end
-  
-
-  
 
   def url_for_document doc, options = {}
     if respond_to?(:blacklight_config) and

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -23,30 +23,35 @@ module CatalogHelper
   def collection_title collection_internal_uri
     collections[collection_internal_uri]
   end
-
-  def render_thumbnail_tag_from_multires_image document, size, counter = nil
-    if is_component?(document)
-      choose_thumbnail document, document.multires_image_file_path, size, counter = nil
-    elsif is_item?(document)
-      response, document_list = find_children(document)
-      choose_thumbnail document, document_list.first.multires_image_file_path, size, counter = nil
-    elsif is_collection?(document)
-      response, documents = find_children(document)
-      response, document_list = find_children(documents.first)
-      choose_thumbnail document, document_list.first.multires_image_file_path, size, counter = nil
+  
+  def render_thumbnail_link document, size, counter = nil
+    path = multires_thumbnail_path(document)
+    if path.present?
+      thumbnail_link_to_document(document, path, size, counter)
     else
       render_thumbnail_tag(document, {}, :counter => counter)
+    end 
+  end
+
+  def multires_thumbnail_path(document)
+    thumbnail_path = nil
+    if document.multires_image_file_paths.present?
+      thumbnail_path = document.multires_image_file_paths.first
+    elsif document.multires_image_file_path.present?
+      thumbnail_path = document.multires_image_file_path
+    else
+      response, child_documents = find_children(document)
+      if child_documents.present?
+        multires_thumbnail_path(child_documents.first)
+      end
     end
   end
 
-  def choose_thumbnail document, multires_image_file_path, size, counter
-    unless multires_image_file_path.blank?
-      image_tag = iiif_image_tag(multires_image_file_path, {:size => size, :alt => 'Thumbnail', :class => 'img-thumbnail'})
-      link_to_document document, image_tag, :counter => counter
-    else
-      render_thumbnail_tag(document, {}, :counter => counter)
-    end
+  def thumbnail_link_to_document(document, multires_image_file_path, size, counter)
+    image_tag = iiif_image_tag(multires_image_file_path, {:size => size, :alt => 'Thumbnail', :class => 'img-thumbnail'})
+    link_to_document document, image_tag, :counter => counter
   end
+
 
   def find_children document, relationship = nil, params = {}
     configure_blacklight_for_children

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,6 +1,6 @@
 <div class="document col-xs-12 col-sm-6 col-md-4">
   <div>
-      <%= render_thumbnail_tag_from_multires_image(document, "!350,350", document_counter_with_offset(document_counter)) %>
+      <%= render_thumbnail_link(document, "!350,350", document_counter_with_offset(document_counter)) %>
     <div class="caption"><%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
     </div>
   </div>

--- a/app/views/catalog/_thumbnail_default.html.erb
+++ b/app/views/catalog/_thumbnail_default.html.erb
@@ -1,3 +1,3 @@
 <div class="document-thumbnail">
-  <%= render_thumbnail_tag_from_multires_image(document, "!200,200", document_counter_with_offset(document_counter)) %>
+  <%= render_thumbnail_link(document, "!200,200", document_counter_with_offset(document_counter)) %>
 </div>  

--- a/lib/ddr/public/version.rb
+++ b/lib/ddr/public/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Public
-    VERSION = "2.0.0"
+    VERSION = "2.0.1"
   end
 end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -56,18 +56,25 @@ RSpec.describe CatalogHelper do
 
   end
 
-  describe "#render_thumbnail_tag_from_multires_image" do
+  describe "#render_thumbnail_link" do
     let(:document) { SolrDocument.new(
             'id'=>'changeme:10',
             ) }
-    context "document is a component" do 
-      it "should receive a message from choose_thumbnail" do
-        choose_thumbnail = double("choose_thumbnail")
-        is_component = double("is_component?")
-        allow(helper).to receive(:is_component?).and_return (true)
-        allow(helper).to receive(:choose_thumbnail).and_return ("path/to/image/")
-        expect(helper).to receive(:choose_thumbnail)
-        helper.render_thumbnail_tag_from_multires_image(document, "100")
+    before { thumbnail_link_to_document = double("thumbnail_link_to_document") }
+    before { multires_thumbnail_path = double("multires_thumbnail_path") }
+    before { render_thumbnail_tag = double("render_thumbnail_tag") }
+    context "document or its children have a multires image" do 
+      it "should receive a message from thumbnail_link_to_document" do
+        allow(helper).to receive(:multires_thumbnail_path).and_return ("path/to/image/")
+        expect(helper).to receive(:thumbnail_link_to_document)
+        helper.render_thumbnail_link(document, "100")
+      end
+    end
+    context "document and its children do not have a multires image" do 
+      it "should receive a message from render_thumbnail_tag" do
+        allow(helper).to receive(:multires_thumbnail_path).and_return (nil)
+        expect(helper).to receive(:render_thumbnail_tag)
+        helper.render_thumbnail_link(document, "100")
       end
     end
   end


### PR DESCRIPTION
I deployed this branch to pre and verified that it fixes the SSL error when viewing a component that has a multires image. Example: https://repository-pre.lib.duke.edu/dc/wdukesons/duke:2061

This branch also disables the histogram feature of the range limit gem to prevent the broken pipe error in the histogram's ajax request. Example: https://repository-pre.lib.duke.edu/dc/wdukesons

I refactored the thumbnail tag helper that was breaking on items without components. It's now agnostic about the type of document being displayed and just checks whether a multires_image_file_path (or multires_image_file_paths) is available on a document or any of that document's children. There isn't a collection deployed to pre that can verify this fix, but I created a collection and child item locally without any components and verified the thumbnail fix.