### PR TITLE
Add rake tasks to generate sitemaps for collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,14 @@
 /config/environments/*.rb
 
 # Pre-compiled assets
+
+# Ddr-portals
+/ddr-portals
+/app/views/ddr-portals/*
+
+# Sitemaps
+/public/sitemaps/*
+
 /public/assets
 
 .sass-cache

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "blacklight_range_limit", :git => 'https://github.com/duke-libraries/blackli
 gem 'prawn'
 gem 'fastimage'
 gem 'bootstrap-select-rails'
+gem 'nokogiri'
 
 gem 'sdoc', '~> 0.4.0', group: :doc
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,6 +452,7 @@ DEPENDENCIES
   launchy
   log4r
   mysql2
+  nokogiri
   openseadragon (~> 0.2.0)
   orderly
   prawn

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,3 +3,5 @@
 # To ban all spiders from the entire site uncomment the next two lines:
 # User-agent: *
 # Disallow: /
+
+Sitemap: https://repository.lib.duke.edu/sitemaps/repository.xml

--- a/public/sitemaps/README.txt
+++ b/public/sitemaps/README.txt
@@ -1,0 +1,5 @@
+To generate sitemaps and sitemap index in this directory run the following rake tasks in production:
+
+rake ddr_public:sitemap:generate[collection pid]
+rake ddr_public:sitemap:index
+


### PR DESCRIPTION
Adds two rake tasks for generating sitemaps:

rake ddr_public:sitemap:generate[collection_pid]
rake ddr_public:sitemap:index (Invoked automatically after 'generate')

Sitemaps are written to: public/sitemaps/ (e.g. public/sitemaps/wdukesons.xml)
The index is written to: public/sitemaps/repository.xml

Since the root url is required in the sitemap and this is not available from rake an additional configuration line is needed in config/local_env.yml for the sitemaps to be generated with complete URLs:

In local_env.yml

ROOT_URL: https://repository.lib.duke.edu
