### PR TITLE
added deep link from item page to row in finding aid

### DIFF
--- a/app/views/catalog/_show_finding_aid.html.erb
+++ b/app/views/catalog/_show_finding_aid.html.erb
@@ -3,6 +3,9 @@
     <div class="buffer-bottom-40">
       <div class="text-muted text-uppercase small strong">Source Collection</div>
         <%= source_collection({ :document => document, :placement => 'left' })  %>
+        <% unless document.aspace_id.blank? %>
+          <p><a href="<%= document.finding_aid.url %>#aspace_<%= document.aspace_id %>" class="text-muted small">View Item in Context</a></p>        
+        <% end %>
     </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
NOTE: Uses aspace_id field, settable in staff UI under Administrative Metadata or via rails console. No items currently have this value on production (awaiting a METS reingest for Rush collection).