### PR TITLE
Copy images into assets directory

### DIFF
--- a/app/assets/images/ddr-portals/README.txt
+++ b/app/assets/images/ddr-portals/README.txt
@@ -1,2 +1,0 @@
-This directory contains symlinks to any image assets for ddr-public portals
-configured in ddr-portals.

--- a/lib/tasks/ddr_public.rake
+++ b/lib/tasks/ddr_public.rake
@@ -192,14 +192,20 @@ namespace :ddr_public do
         sh "ln -s #{dir} #{PORTAL_VIEW_PATH}/#{setname}" if File.directory?(dir)
 
         dir = set_repo_path + "/assets/images"
-        sh "ln -s #{dir} #{PORTAL_IMAGES_PATH}/#{setname}" if File.directory?(dir)
+        sh "cp -r #{dir} #{PORTAL_IMAGES_PATH}/#{setname}" if File.directory?(dir)
+
+        if Rails.env.production?
+          Rake::Task["assets:precompile"]
+        end
 
       end
     end
 
-    desc "Clean all view symlinks without removing the git repository"
-    task :clean_links => [PORTAL_VIEW_PATH] do
+    desc "Clean all view symlinks and image directories without removing the git repository"
+    task :clean_links => [PORTAL_VIEW_PATH, PORTAL_IMAGES_PATH] do
       sh "find #{PORTAL_VIEW_PATH} -type l -exec rm {} \\;"
+      sh "rm -rf #{PORTAL_IMAGES_PATH}"
+      sh "mkdir #{PORTAL_IMAGES_PATH}"
     end
 
     desc "Clean all portal-specific views, including the repository"


### PR DESCRIPTION
Images can be added to ddr-portals for about pages such as for the hmp portal:

ddr-portals/hmp/assets/images/hmp-notes.jpg

These will be copied to:

app/assets/images/ddr-portals/hmp/hmp-notes.jpg

Include this image in about pages or elsewhere with the following helper:

image_tag("ddr-portals/hmp/hmp-notes.jpg")