### PR TITLE
make default highlights section show 4 items instead of 8

### DIFF
--- a/app/views/digital_collections/_home_highlights.html.erb
+++ b/app/views/digital_collections/_home_highlights.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-md-12">
       <% unless @highlight_documents.empty? %>
-        <% @highlight_documents.sample(@highlight_count ||= 8).each_with_index do |doc, index| %>
+        <% @highlight_documents.sample(@highlight_count ||= 4).each_with_index do |doc, index| %>
           <% if doc.multires_image_file_paths.first %>
             <div class="collection-highlight" id="collection-highlight-<%= index %>" style="background-image: url(<%= iiif_image_path(doc.multires_image_file_paths.first, {:size => '!500,500', :region => 'pct:5,5,90,90' }) %>);">
 


### PR DESCRIPTION
Latest round of stakeholder meetings review reveal preference for four, especially with photo collections.