### PR TITLE
Move blacklight configs to separate concern

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -7,6 +7,7 @@ class CatalogController < ApplicationController
 
   include Blacklight::Catalog
   include Hydra::Controller::ControllerBehavior
+  include Ddr::Public::Controller::ConfigureBlacklight
 
   before_action :enforce_show_permissions, only: :show
 
@@ -89,9 +90,9 @@ class CatalogController < ApplicationController
     # config.add_facet_field solr_name('lc1_letter', :facetable), :label => 'Call Number'
     # config.add_facet_field solr_name('subject_geo', :facetable), :label => 'Region'
     # config.add_facet_field solr_name('subject_era', :facetable), :label => 'Era'
-    config.add_facet_field Ddr::Index::Fields::ADMIN_SET_FACET.to_s, label: 'Collection Group', helper_method: 'admin_set_full_name', collapse: false, limit: 5
-    config.add_facet_field Ddr::Index::Fields::COLLECTION_FACET.to_s, label: 'Collection', helper_method: 'collection_title', limit: 5
-    config.add_facet_field Ddr::Index::Fields::ACTIVE_FEDORA_MODEL.to_s, label: 'Browse', show: false
+    # config.add_facet_field Ddr::Index::Fields::ADMIN_SET_FACET.to_s, label: 'Collection Group', helper_method: 'admin_set_full_name', collapse: false, limit: 5
+    # config.add_facet_field Ddr::Index::Fields::COLLECTION_FACET.to_s, label: 'Collection', helper_method: 'collection_title', limit: 5
+    # config.add_facet_field Ddr::Index::Fields::ACTIVE_FEDORA_MODEL.to_s, label: 'Browse', show: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/app/controllers/concerns/ddr/public/controller/configure_blacklight.rb
+++ b/app/controllers/concerns/ddr/public/controller/configure_blacklight.rb
@@ -1,0 +1,66 @@
+module Ddr
+  module Public
+    module Controller
+      module ConfigureBlacklight
+        extend ActiveSupport::Concern
+
+        def self.included(base)
+          base.before_action :configure_blacklight_facets
+          base.before_action :configure_blacklight_show_fields
+          base.before_action :configure_blacklight_index_fields
+        end
+
+        def configure_blacklight_facets
+          configure_blacklight({
+            clear_field: 'facet_fields',
+            add_field: 'add_facet_field'})
+        end
+
+        def configure_blacklight_show_fields
+          configure_blacklight({
+            clear_field: 'show_fields',
+            add_field: 'add_show_field'})
+        end
+
+        def configure_blacklight_index_fields
+          configure_blacklight({
+            clear_field: 'index_fields',
+            add_field: 'add_index_field'})
+        end
+
+        def configure_blacklight options={}
+          if conf = portal_config.try(:[], 'configure_blacklight').try(:[], options[:add_field])
+            blacklight_config.send(options[:clear_field]).clear
+            conf.each do |field|
+              blacklight_config.send(options[:add_field],
+                constantize_solr_field_string({solr_field: field['field']}),
+                :label => field['label'],
+                :show => field['show'],
+                :collapse => field['collapse'],
+                :limit => field['limit'],
+                :sort => field['sort'],
+                :range => field['range'],
+                :helper_method => field['helper_method'],
+                :link_to_search => if field['link_to_search'] then constantize_solr_field_string({solr_field: field['link_to_search']}) end
+                )
+            end
+          end
+        end
+
+        def portal_config
+          portal_config = Rails.application.config.try(:portal).try(:[], 'controllers').try(:[], params[:collection])
+          portal_config ||= Rails.application.config.try(:portal).try(:[], 'controllers').try(:[], controller_name)
+        end
+
+        def constantize_solr_field_string options={}
+          if options[:solr_field].respond_to? :each
+            ActiveFedora::SolrService.solr_name(*options[:solr_field]).to_s
+          else
+            options[:solr_field].safe_constantize.to_s
+          end
+        end
+        
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/ddr/public/controller/portal.rb
+++ b/app/controllers/concerns/ddr/public/controller/portal.rb
@@ -6,8 +6,6 @@ module Ddr
         extend ActiveSupport::Concern
           
         def self.included(base)
-          base.before_action :configure_blacklight_facets
-          base.before_action :configure_blacklight_show_fields
           base.before_action :prepend_view_path_for_portal_overrides
           base.before_action :parent_collection_uris
           
@@ -108,35 +106,6 @@ module Ddr
 
         def prepend_view_path_for_portal_overrides
           prepend_view_path "app/views/ddr-portals/#{params[:collection] || controller_name}"
-        end
-
-        def configure_blacklight_facets
-          if portal_config.try(:[], 'configure_blacklight').try(:[], 'add_facet_fields')
-            blacklight_config.facet_fields.clear
-            portal_config['configure_blacklight']['add_facet_fields'].each do |facet|
-              blacklight_config.add_facet_field eval(facet['field']).to_s,
-                :label => facet['label'],
-                :show => facet['show'],
-                :collapse => facet['collapse'],
-                :limit => facet['limit'],
-                :sort => facet['sort'],
-                :range => facet['range'],
-                :helper_method => facet['helper_method']
-            end
-          end
-        end
-
-        def configure_blacklight_show_fields
-          if portal_config.try(:[], 'configure_blacklight').try(:[], 'add_show_fields')
-            blacklight_config.show_fields.clear
-            portal_config['configure_blacklight']['add_show_fields'].each do |show_field|
-              blacklight_config.add_show_field eval(show_field['field']).to_s,
-                :separator => show_field['separator'],
-                :label => show_field['label'],
-                :helper_method => show_field['helper_method'],
-                :link_to_search => if show_field['link_to_search'] then eval(show_field['link_to_search']) end
-            end
-          end
         end
 
       end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -109,7 +109,6 @@ module CatalogHelper
     end
   end
 
-
   # View helper
   def render_content_type_and_size document
     "#{document.content_mime_type} #{document.content_size_human}"


### PR DESCRIPTION
This pull request includes a few changes related to how Blacklight can be configured from ddr-portals.

- In addition to add_show_field and add_facet_field, you can now configure Blacklight using add_index_field from ddr-portals.
- Some Blacklight configurations previously set in the CatalogController are now set in ddr-portals/catalog.
- An updated version of ddr-portals is required -- see the index-field-config branch of ddr-portals.