### PR TITLE
Setup for digital collections portal

### DIFF
--- a/app/assets/stylesheets/ddr.css.scss
+++ b/app/assets/stylesheets/ddr.css.scss
@@ -66,10 +66,6 @@ a.navbar-dul {
         }
       }
 
-      // Hide Digital Collections as a search scope until there are more published collections.
-      & ul.selectpicker li a[data-normalized-text*="Digital Collections"] {
-        display: none;
-      }
     }
 
     & input#q {

--- a/app/controllers/digital_collections_controller.rb
+++ b/app/controllers/digital_collections_controller.rb
@@ -3,7 +3,7 @@
 class DigitalCollectionsController < CatalogController
   include Ddr::Public::Controller::Portal
 
-  # This enables us to use a .rb template to render json for the media action
+  # Enables us to use a .rb template to render json for the media action
   ActionView::Template.register_template_handler(:rb, :source.to_proc)
 
   # This has to run after get_pid_from_params_id
@@ -25,13 +25,22 @@ class DigitalCollectionsController < CatalogController
     end
     collection_document
     alert_message
-    search_scopes
+  end
+
+  # Action exists to distinguish between the collection
+  # scoped dc/:collection portals and the  dc/ portal
+  # This is for the dc/ portal page
+  def index_portal
+    index
+
+    collection_count
+    item_count
+    featured_collection_documents
   end
 
   def show
     super
     collection_document
-    search_scopes
     max_download
   end
 
@@ -40,7 +49,6 @@ class DigitalCollectionsController < CatalogController
   end
 
   def about
-    search_scopes
     collection_document
   end
 
@@ -49,7 +57,6 @@ class DigitalCollectionsController < CatalogController
   end
 
   def featured
-    search_scopes
     collection_document
     showcase_documents
     highlight_documents

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -130,17 +130,22 @@ module CatalogHelper
   end
 
   # View helper
-  def search_scope_dropdown current_search_scopes = nil
-    all_search_scopes = all_search_scopes()
+  def render_search_scope_dropdown params={}
+    active_search_scopes = []
 
-    if current_search_scopes.present?
-      current_search_scope_options = []
-      current_search_scopes.each do |scope_name|
-        current_search_scope_options << all_search_scopes[scope_name]
-      end
-      render partial: "search_scope_dropdown", locals: {current_search_scope_options: current_search_scope_options}
+    if request.path =~ /^\/dc\/.*$/
+      active_search_scopes << ["This Collection", digital_collections_url(params[:collection])]
     end
 
+    if request.path =~ /^\/dc.*$/
+      active_search_scopes << ["Digital Collections", digital_collections_index_portal_url]
+    end
+
+    active_search_scopes << ["Digital Repository", catalog_index_url]
+
+    if active_search_scopes.count > 1
+      render partial: "search_scope_dropdown", locals: {active_search_scope_options: active_search_scopes}
+    end
   end
   
   def finding_aid_popover finding_aid
@@ -201,11 +206,6 @@ module CatalogHelper
 
 
   private
-
-  def all_search_scopes
-    {:search_action_url => ["This Collection", search_action_url],
-     :catalog_index_url => ["Digital Repository", catalog_index_url]}
-  end
 
   def find_relationship document
     if document.active_fedora_model == 'Item'

--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -28,13 +28,20 @@
   <% end %>
 
   <% unless params["range"] && params["range"][solr_field] && params["range"][solr_field]["missing"] %>
+  
+    <!-- TODO: There is probably a better approach but this works for now.
+         Range Limit assumes you're always using the catalog index route.
+         To support our portal index routes we need this additional logic. -->
     <% if controller_name == 'catalog' %>
       <% controller_index_name = 'catalog_index' %>
-    <% else %>
+    <% elsif params[:collection] == nil %>
+      <% controller_index_name = "#{controller_name}_index_portal" %>
+    <% else  %>
       <% controller_index_name = controller_name %>
-    <% end  %>
-    <!-- TODO this needs to be catalog_index_path for the catalog controller routes -->
-    <%= form_tag eval("#{controller_index_name}_path"), :method => :get, :class=>"range_limit subsection range_#{solr_field} form-inline" do %>
+    <% end %>
+    
+    <%= form_tag Rails.application.routes.url_helpers.send("#{controller_index_name}_path", :collection => params[:collection]), :method => :get, :class=>"range_limit subsection range_#{solr_field} form-inline" do %>
+
       <%= render_hash_as_hidden_fields(params_for_search) %>
       
       <!-- we need to include a dummy search_field parameter if none exists,

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,9 +1,7 @@
 <%= form_tag search_action_url, :method => :get, :class => 'search-query-form form-inline clearfix navbar-form' do %>
   <%= render_hash_as_hidden_fields(params_for_search().except(:q, :search_field, :qt, :page, :utf8)) %>
   <div class="input-group">
-    <% if @search_scopes.present? %>
-      <%= search_scope_dropdown(@search_scopes) %>
-    <% end %>
+    <%= render_search_scope_dropdown(params) %>
     <%= label_tag 'q', 'Search', class: 'mast-search' %>
     <%= text_field_tag :q, params[:q], :placeholder => t('blacklight.search.form.q'), :class => "search_q q form-control", :id => "q", :autofocus => should_autofocus_on_search_box? %>
 

--- a/app/views/catalog/_search_scope_dropdown.html.erb
+++ b/app/views/catalog/_search_scope_dropdown.html.erb
@@ -1,3 +1,3 @@
 <div class="input-group-btn scope-btn">
-  <%= select_tag(nil, options_for_select(current_search_scope_options, h(params[:search_field])), :title => t('blacklight.search.form.search_field.title'), :class=>"selectpicker search_scope form-control") %>
+  <%= select_tag(nil, options_for_select(active_search_scope_options, h(params[:search_field])), :title => t('blacklight.search.form.search_field.title'), :class=>"selectpicker search_scope form-control") %>
 </div>

--- a/app/views/digital_collections/index_portal.html.erb
+++ b/app/views/digital_collections/index_portal.html.erb
@@ -1,0 +1,47 @@
+<!-- This can become whatever we need it to be to support -->
+<!-- the dc/ portal page -->
+
+<div id="home-branding" class="col-sm-12">
+  <!-- Could have two branding templates -->
+  <!-- One for the collection portal page -->
+  <!-- And one for the search results page and/or show pages -->
+  <!-- Select one or the other using the has_search_parameters? check as below -->
+  <%= @item_count %>
+  <%= @collection_count %>
+  <%= @featured_collection_documents %>
+  <% if @collection_document %>
+    <%= render 'home_showcase' %>
+  <% else %>
+    <h1><%= t("ddr.public.portal.#{params[:collection] || controller_name}.title") %></h1>
+  <% end %>
+</div>
+
+<div id="sidebar" class="col-md-3 col-sm-4">
+  
+  <% if @collection_document %>
+    <%= render partial: 'show_research_help', locals: { document: @collection_document }  %>
+    
+    <% if has_search_parameters? %>
+      <%= render partial: 'show_collection_context', locals: { document: @collection_document } %>     
+    <% end %>
+    
+  <% end %>
+
+  <%= render 'search_sidebar' %>
+</div>
+
+<div id="content" class="col-md-9 col-sm-8">
+  <% unless has_search_parameters? %>
+    <%# if there are no input/search related params, display the "home" partial -%>
+    <%= render 'home' %>
+    
+    <%# set the html title for collection portal page -%>
+    <% if @collection_document %>
+      <%= content_for :page_title, t("ddr.public.portal.#{params[:collection] || controller_name}.title", :default => @collection_document.title) + " - Duke Libraries" %>
+    <% else %>
+      <%= content_for :page_title, t("ddr.public.portal.#{params[:collection] || controller_name}.title", :default => t("blacklight.welcome"))  %>
+    <% end %>
+  <% else %>
+    <%= render 'search_results' %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,11 @@ Rails.application.routes.draw do
 
   blacklight_for :catalog
 
+  # Range Limit and Facet routes for DC
   get "dc/range_limit/", to: "digital_collections#range_limit"
   get "dc/facet/:id", to: "digital_collections#facet", as: "digital_collections_facet"
+  
+  # DC Collection scoped routes
   constraints Collection do
     get "dc/:collection/featured", to: "digital_collections#featured", as: "featured_items"
     get "dc/:collection/about", :to => "digital_collections#about", as: "digital_collections_about"
@@ -13,8 +16,15 @@ Rails.application.routes.draw do
     get "dc/:collection/:id", to: "digital_collections#show"
     get "dc/:collection", to: "digital_collections#index", as: "digital_collections"
   end
+  
+  # Special named route just for DC Portal to distinguish
+  # from DC collection portals
+  get "dc" => "digital_collections#index_portal", as: "digital_collections_index_portal"
+
+  # Must exist for facets to work from DC portal
   get "dc" => "digital_collections#index"
 
+  # Constrain DC Collection Routes to those configured
   class Collection
     def self.matches?(request)
       Rails.application.config.portal.try(:[], 'portals').try(:[], 'collection_local_id').keys.include?(request.params[:collection])

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -91,30 +91,39 @@ RSpec.describe CatalogHelper do
     end
   end
 
-  describe "#search_scope_dropdown" do
-    let(:current_search_scope_options) do
-      [nil]
-    end
-    let(:search_scopes) do
-      {:search_action_url => ["This Collection", "http://localhost:3000/dc/wdukesons"],
-       :digital_collections => ["Digital Collections", "http://localhost:3000/dc"],
-       :catalog_index_url => ["Digital Repository", "http://localhost:3000/catalog"]}
-    end
-    before {all_search_scopes = double("all_search_scopes")}
-    before {allow(helper).to receive(:all_search_scopes).and_return(search_scopes)}
-    context "search scopes is defined" do
-      let(:current_search_scopes) do
-        [:search_action_url, :digital_collections, :catalog_index_url]
-      end
+  describe "#render_search_scope_dropdown" do
+    let(:path) { '/dc' }
+    let(:request) { double('request', path: path) }
+
+    let(:collection) { ["This Collection", digital_collections_url('hmp')] }
+    let(:digital_collections) { ["Digital Collections", digital_collections_index_portal_url] }
+    let(:repository) { ["Digital Repository", catalog_index_url] }
+
+    before  { allow(helper).to receive(:request).and_return(request) }
+
+    context "request path is the digital collections portal" do
+      let(:active_search_scope_options) { [digital_collections, repository] }
       it "should render the partial for the scope dropdown" do
-        expect(helper).to receive(:render).with(partial: "search_scope_dropdown", locals: {current_search_scope_options: current_search_scope_options})
-        helper.search_scope_dropdown(current_search_scopes: current_search_scopes)
+        expect(helper).to receive(:render).with(partial: "search_scope_dropdown", locals: {active_search_scope_options: active_search_scope_options})
+        helper.render_search_scope_dropdown()
       end
     end
-    context "search scopes is not defined" do
-      it "should not render the partial" do
-        expect(helper).not_to receive(:render).with(partial: "search_scope_dropdown", locals: {current_search_scope_options: current_search_scope_options})
-        helper.search_scope_dropdown()
+
+    context "request path is a collection" do
+      let(:path) { '/dc/hmp' }
+      let(:active_search_scope_options) { [collection, digital_collections, repository] }
+      it "should render the partial for the scope dropdown" do
+        expect(helper).to receive(:render).with(partial: "search_scope_dropdown", locals: {active_search_scope_options: active_search_scope_options})
+        helper.render_search_scope_dropdown({collection: 'hmp'})
+      end
+    end
+
+    context "only the catalog search scope is applied" do
+      let(:path) { '/catalog' }
+      let(:active_search_scope_options) { [repository] }
+      it "should not render the partial for the scope dropdown" do
+        expect(helper).not_to receive(:render)
+        helper.render_search_scope_dropdown()
       end
     end
   end


### PR DESCRIPTION
* Adds a new route (digital_collections_index_portal), DigitalCollectionsController action (index_portal), and index_portal.html.erb template to support the /dc portal
* Adds @featured_collection_documents, @collection_count, @item_count to the index_portal action
* Search scopes now render depending on the current request path
* Fixes routes for Blacklight Range Limit use on the /dc portal 