### PR TITLE
Hotfix 2.2.1 - Adds item full text to default search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '~> 4.1.6'
 gem 'hydra-head', '~> 7.2.0'
 gem 'ddr-alerts', '~> 1.0.0'
 gem 'devise' # must be explicitly required
-gem 'ddr-models', '2.4.1'
+gem 'ddr-models', '2.4.8'
 
 gem 'log4r'
 gem 'bootstrap-sass', '~> 3.3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,13 +119,13 @@ GEM
     ddr-alerts (1.0.0)
       rails (~> 4.1.6)
     ddr-antivirus (2.1.1)
-    ddr-models (2.4.1)
+    ddr-models (2.4.8)
       active-fedora (~> 7.0)
       activeresource
       cancancan (~> 1.12)
       ddr-antivirus (~> 2.1.1)
       devise (~> 3.4)
-      ezid-client (~> 1.1, >= 1.1.1)
+      ezid-client (~> 1.4.2)
       grouper-rest-client
       hashie (~> 3.4.3)
       hydra-core (~> 7.2)
@@ -159,7 +159,7 @@ GEM
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
     execjs (2.5.2)
-    ezid-client (1.2.0)
+    ezid-client (1.4.2)
       hashie
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -202,7 +202,7 @@ GEM
     hydra-validations (0.5.0)
       activemodel (~> 4.0)
     i18n (0.7.0)
-    ice_nine (0.11.1)
+    ice_nine (0.11.2)
     jbuilder (2.2.6)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
@@ -253,7 +253,7 @@ GEM
     multi_json (1.10.1)
     mysql2 (0.3.17)
     net-http-persistent (2.9.4)
-    net-ldap (0.13.0)
+    net-ldap (0.14.0)
     netrc (0.10.2)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
@@ -400,8 +400,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    sinatra (1.4.6)
-      rack (~> 1.4)
+    sinatra (1.4.7)
+      rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     solrizer (3.3.0)
@@ -473,7 +473,7 @@ DEPENDENCIES
   coffee-rails (~> 4.0.0)
   database_cleaner
   ddr-alerts (~> 1.0.0)
-  ddr-models (= 2.4.1)
+  ddr-models (= 2.4.8)
   devise
   edtf-humanize!
   factory_girl_rails (~> 4.4)
@@ -500,4 +500,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -50,7 +50,8 @@ class CatalogController < ApplicationController
               solr_name(:spatial, :stored_searchable),
               Ddr::Index::Fields::LOCAL_ID,
               solr_name(:identifier, :stored_searchable),
-              Ddr::Index::Fields::PERMANENT_ID].join(' ')
+              Ddr::Index::Fields::PERMANENT_ID,
+              Ddr::Index::Fields::ALL_TEXT].join(' ')
     }
     
     config.per_page = [10,20,50,100]

--- a/lib/ddr/public/version.rb
+++ b/lib/ddr/public/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Public
-    VERSION = "2.2.0"
+    VERSION = "2.2.1"
   end
 end


### PR DESCRIPTION
Upgrades ddr-models to v2.4.8.

@corylown @seanaery Let me know if you have concerns.  I do not believe this change will have a practical effect on any published collections b/c none AFAIK has extracted text for full text searching.