### PR TITLE
Add helper to generate derivative URLs for audio and video items

### DIFF
--- a/app/controllers/concerns/ddr/public/controller/portal.rb
+++ b/app/controllers/concerns/ddr/public/controller/portal.rb
@@ -48,13 +48,16 @@ module Ddr
           @max_download ||= portal_config.try(:[], 'restrictions').try(:[], 'max_download')
         end
 
-
         def blog_posts_url
           @blog_post_url ||= portal_config.try(:[], 'blog_posts')
         end
 
         def alert_message
           @portal_alert_message ||= portal_config.try(:[], 'alert')
+        end
+
+        def derivative_url_prefixes
+          @derivative_url_prefixes ||= portal_config.try(:[], 'derivative_url_prefixes')
         end
 
         def include_only_specified_records(solr_parameters, user_parameters)

--- a/app/controllers/digital_collections_controller.rb
+++ b/app/controllers/digital_collections_controller.rb
@@ -14,6 +14,10 @@ class DigitalCollectionsController < CatalogController
   before_action :get_pid_from_params_id, only: [:show, :media]
   before_action :enforce_show_permissions, only: :show
 
+  configure_blacklight do |config|
+    config.view.gallery.default = true
+  end
+
   def index
     super
     unless has_search_parameters?
@@ -37,13 +41,13 @@ class DigitalCollectionsController < CatalogController
     collection_count
     item_count
     featured_collection_documents
-
   end
 
   def show
     super
     collection_document
     max_download
+    derivative_url_prefixes
   end
 
   def media
@@ -52,10 +56,6 @@ class DigitalCollectionsController < CatalogController
 
   def about
     collection_document
-  end
-
-  configure_blacklight do |config|
-    config.view.gallery.default = true
   end
 
   def featured

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -161,10 +161,27 @@ module CatalogHelper
     end
     
   end
+
+  def derivative_urls options={}
+    derivative_urls = []
+    options[:document].derivative_ids.each do |id|
+       derivative_urls << "#{options[:derivative_url_prefixes][options[:document].display_format]}#{id}.#{derivative_file_extension(options[:document])}"
+    end
+
+    derivative_urls
+  end
   
 
-
   private
+
+  def derivative_file_extension document
+    case document.display_format
+    when "audio"
+      "mp3"
+    when "video"
+      "mp4"
+    end
+  end
 
   def find_relationship document
     if document.active_fedora_model == 'Item'

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -57,6 +57,11 @@ class SolrDocument
       public_id = self.id unless Rails.application.config.portal.try(:[], 'portals').try(:[], 'collection_local_id').try(:[], self.local_id)
     end
   end
+
+  # This assumes that the derivative IDs are the local_ids of an item's components
+  def derivative_ids(type='default')
+    struct_map_docs(type).map { |doc| doc.local_id }.compact
+  end
   
 
   private
@@ -75,6 +80,8 @@ class SolrDocument
     local_id = SolrDocument.find(self.admin_policy_pid).local_id
     Rails.application.config.portal.try(:[], 'portals').try(:[], 'collection_local_id').try(:[], local_id)
   end
+
+
 
 
 end

--- a/app/views/catalog/_show_audio_item.html.erb
+++ b/app/views/catalog/_show_audio_item.html.erb
@@ -1,0 +1,1 @@
+<%= derivative_urls({document: document, derivative_url_prefixes: @derivative_url_prefixes}) %>

--- a/app/views/catalog/_show_video_item.html.erb
+++ b/app/views/catalog/_show_video_item.html.erb
@@ -1,0 +1,1 @@
+<%= derivative_urls({document: document, derivative_url_prefixes: @derivative_url_prefixes}) %>

--- a/config/initializers/portal.rb
+++ b/config/initializers/portal.rb
@@ -1,21 +1,47 @@
-unless Dir.glob(Rails.root.join('ddr-portals', '*/')).blank?
-  portal_directories = Dir.glob(Rails.root.join('ddr-portals', '*/'))
+def configure_ddr_public_portals
+  formatted_configs = config_format()
 
-  loaded_configs = {"portals" => {"collection_local_id" => {}, "admin_sets" => {}}, "controllers" => {}}
+  portal_directories.each do |portal_directory|
 
-  portal_directories.each do |portal|
-    portal_name = portal.split("/").last
-    loaded_configs["controllers"][portal_name] = YAML.load_file(portal + 'portal_view_configs.yml')[Rails.env]
-    portals_doc_configs = YAML.load_file(portal + 'portal_doc_configs.yml')[Rails.env]
-    if portals_doc_configs["collection_local_id"]
-      loaded_configs["portals"]["collection_local_id"].merge!(portals_doc_configs["collection_local_id"])
+    formatted_configs["controllers"][portal_name(portal_directory)] = load_portal_view_configs(portal_directory)
+
+    if portal_doc_configs = load_portal_doc_configs(portal_directory)
+      formatted_configs["portals"]["collection_local_id"].merge!(portal_doc_configs["collection_local_id"] || {})
+      formatted_configs["portals"]["admin_sets"].merge!(portal_doc_configs["admin_sets"] || {})
     end
-    if portals_doc_configs["admin_sets"]
-      loaded_configs["portals"]["admin_sets"].merge!(portals_doc_configs["admin_sets"])
-    end
+
   end
 
-  Rails.application.config.portal = loaded_configs
-else
+  formatted_configs
+end
+
+def portal_name(portal_directory)
+  portal_directory.split("/").last
+end
+
+def load_portal_view_configs(portal_directory)
+  YAML.load_file("#{portal_directory}portal_view_configs.yml")
+end
+
+def load_portal_doc_configs(portal_directory)
+  file_path = "#{portal_directory}portal_doc_configs.yml"
+  if File.exist?(file_path)
+    YAML.load_file(file_path)
+  end
+end
+
+def portal_directories
+  Dir.glob(Rails.root.join('ddr-portals', '*/'))
+end
+
+def config_format
+  {"portals" => {"collection_local_id" => {}, "admin_sets" => {}}, "controllers" => {}}
+end
+
+
+
+if Dir.glob(Rails.root.join('ddr-portals', '*/')).blank?
   Rails.application.config.portal = {}
+else
+  Rails.application.config.portal = configure_ddr_public_portals()
 end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -149,4 +149,14 @@ RSpec.describe CatalogHelper do
     end        
   end
 
+  describe "#derivative_urls" do
+    context "item is display_format audio" do
+      let(:prefixes) { {'audio' => "http://library.duke.edu/derivatives/"} }
+      it "should return an array of audio derivative URLs" do
+        document = double("document", :derivative_ids => ["audio_100"], :display_format => "audio")
+        expect(helper.derivative_urls({document: document, derivative_url_prefixes: prefixes })).to match(['http://library.duke.edu/derivatives/audio_100.mp3'])
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
- Adds two partials for audio and video items (app/views/catalog/_show_audio_item.html.erb and app/views/catalog/_show_video_item.html.erb)
- New helper method (derivative_urls) to return an array of derivative URLs for the current item. See example of use in the above partials.
- Minor refactoring of portal.rb initializer for clarity and to make it not required.