### PR TITLE
Add XML feed for DPLA metadata harvesting

### DIFF
--- a/app/controllers/digital_collections_controller.rb
+++ b/app/controllers/digital_collections_controller.rb
@@ -11,7 +11,7 @@ class DigitalCollectionsController < CatalogController
   # CatalogController.
   skip_filter :enforce_show_permissions, only: :show
 
-  before_action :get_pid_from_params_id, only: [:show, :media]
+  before_action :get_pid_from_params_id, only: [:show, :media, :feed]
   before_action :enforce_show_permissions, only: :show
 
   configure_blacklight do |config|
@@ -48,6 +48,10 @@ class DigitalCollectionsController < CatalogController
     collection_document
     max_download
     derivative_url_prefixes
+  end
+
+  def feed
+    @document = SolrDocument.find(params[:id])
   end
 
   def media

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -107,7 +107,8 @@ module CatalogHelper
       render partial: "search_scope_dropdown", locals: {active_search_scope_options: active_search_scopes}
     end
   end
-  
+
+  # View helper
   def finding_aid_popover finding_aid
     popover = ''
     if finding_aid.collection_title
@@ -161,6 +162,26 @@ module CatalogHelper
     end
     
   end
+
+  # DPLA Feed document helper
+  def thumbnail_url document
+    if multires_thumbnail_image_file_path = multires_thumbnail_image_file_path(document)
+      iiif_image_path(multires_thumbnail_image_file_path, {size: '!300,300'})
+    else
+      url_for controller: :thumbnail, action: :show, id: document.id, only_path: false
+    end
+  end
+
+  # DPLA Feed document helper
+  def source_collection_title document
+    document.try(:finding_aid).try(:collection_title)
+  end
+
+  # DPLA Feed document helper
+  def research_help_name document
+    document.try(:research_help).try(:name)
+  end
+  
 
   def derivative_urls options={}
     derivative_urls = []

--- a/app/helpers/show_feed_helper.rb
+++ b/app/helpers/show_feed_helper.rb
@@ -1,0 +1,67 @@
+module ShowFeedHelper
+
+  def field_value_mappings options={}
+    feed_to_duke_value_mapping = []
+
+    options[:field_configs].each do |feed_field, local_fields|
+      namespace, field = feed_field.to_s.split(':')
+      local_fields.each do |local_field|
+        values = field_values({ local_field: local_field, document: options[:document] })
+
+        Array(values).each do |value|
+          if value
+            feed_to_duke_value_mapping << field_value_mapping({ field: field, namespace: namespace, value: value })
+          end
+        end
+
+      end
+    end
+
+    feed_to_duke_value_mapping
+  end
+
+  private
+
+  def field_values options={}
+    case
+    when options[:local_field].has_key?(:solr_field)
+      solr_field_value ({ helper_method: options[:local_field][:helper_method], solr_field: options[:local_field][:solr_field], document: options[:document] })
+    when options[:local_field].has_key?(:document_helper)
+      document_helper_value ({ helper_method: options[:local_field][:document_helper], document: options[:document] })
+    when options[:local_field].has_key?(:value)
+      value({ value: options[:local_field][:value] })
+    end
+  end
+
+  def field_value_mapping options={}
+    { dpla_field: options[:field], namespace: options[:namespace], duke_value: options[:value] }
+  end
+
+  def document_helper_value options={}
+    send options[:helper_method], options[:document]
+  end
+
+  def solr_field_value options={}
+    solr_field_name = constantize_solr_field_string({ solr_field: options[:solr_field] })
+    values = options[:document][solr_field_name.to_s]
+
+    if options[:helper_method] and values
+      values = send options[:helper_method].to_s, { value: values }
+    end
+
+    values
+  end
+
+  def value options={}
+    options[:value]
+  end
+
+  def constantize_solr_field_string options={}
+    if options[:solr_field].respond_to? :each
+      ActiveFedora::SolrService.solr_name(*options[:solr_field])
+    else
+      options[:solr_field].safe_constantize
+    end
+  end
+
+end

--- a/app/views/digital_collections/feed.xml.rb
+++ b/app/views/digital_collections/feed.xml.rb
@@ -1,0 +1,23 @@
+feed_mapping = field_value_mappings({
+  field_configs: Rails.application.config.dpla_mapping[:dpla_fields],
+  document: @document
+})
+
+namespaces = {
+"xmlns:dul_dc" => "#{root_url}schemas/dul_dc/",
+"xmlns:dc" => "http://purl.org/dc/elements/1.1/",
+"xmlns:dcterms" => "http://purl.org/dc/terms/",
+"xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance",
+"xsi:schemaLocation" => "#{root_url}schemas/dul_dc/ #{root_url}schemas/dul_dc.xsd"
+}
+
+builder = Nokogiri::XML::Builder.new do |xml|
+  xml.dc(namespaces) {
+    feed_mapping.each do |mappings|
+      xml[mappings[:namespace]].send("#{mappings[:dpla_field]}_", mappings[:duke_value])
+    end
+    xml.parent.namespace = xml.parent.namespace_definitions.find{|ns|ns.prefix=="dul_dc"}
+  }
+end
+
+builder.to_xml

--- a/config/dpla_mapping.yml.sample
+++ b/config/dpla_mapping.yml.sample
@@ -1,0 +1,61 @@
+dpla_fields:
+  'dcterms:isPartOf':
+    - document_helper: :source_collection_title
+  'dc:contributor':
+    - solr_field: 
+      - :contributor
+      - :stored_searchable
+  'dc:coverage':
+    - solr_field:
+      - :spatial
+      - :stored_searchable
+  'dc:creator':
+    - solr_field: 
+      - :creator
+      - :stored_searchable
+  'dc:date':
+    - solr_field:
+      - :date
+      - :stored_searchable
+      helper_method: :display_edtf_date
+  'dc:description':
+    - solr_field:
+      - :description
+      - :stored_searchable
+  'dc:format':
+    - solr_field:
+      - :format
+      - :stored_searchable
+  'dc:identifier':
+    - solr_field:
+      - :local_id
+      - :stored_sortable
+    - document_helper: :thumbnail_url
+    - solr_field:
+      - :permanent_url
+      - :stored_sortable
+  'dc:language':
+    - solr_field:
+      - :language
+      - :stored_searchable
+      helper_method: :language_display
+  'dc:publisher':
+    - solr_field:
+      - :publisher
+      - :stored_searchable
+  'dc:rights':
+    - solr_field:
+      - :rights
+      - :stored_searchable
+  'dc:subject':
+    - solr_field:
+      - :subject
+      - :stored_searchable
+  'dc:title':
+    - solr_field:
+      - :title
+      - :stored_searchable
+  'dc:type':
+    - solr_field:
+      - :type
+      - :stored_searchable

--- a/config/initializers/dpla_mapping.rb
+++ b/config/initializers/dpla_mapping.rb
@@ -1,0 +1,1 @@
+Rails.application.config.dpla_mapping = YAML.load_file(Rails.root.join('config', 'dpla_mapping.yml')).deep_symbolize_keys

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,8 @@ Rails.application.routes.draw do
   constraints Collection do
     get "dc/:collection/featured", to: "digital_collections#featured", as: "featured_items"
     get "dc/:collection/about", :to => "digital_collections#about", as: "digital_collections_about"
-    get "dc/:collection/:id/media", :to => "digital_collections#media"
+    get "dc/:collection/:id/media", :to => "digital_collections#media", constraints: { format: 'json' }
+    get "dc/:collection/:id/feed", :to => "digital_collections#feed", constraints: { format: 'xml' }
     get "dc/:collection/:id", to: "digital_collections#show"
     get "dc/:collection", to: "digital_collections#index", as: "digital_collections"
   end

--- a/public/schemas/dul_dc.xsd
+++ b/public/schemas/dul_dc.xsd
@@ -1,0 +1,82 @@
+<schema targetNamespace="http://repository.lib.duke.edu/schemas/dul_dc/" 
+        xmlns:dul_dc="http://repository.lib.duke.edu/schemas/dul_dc/" 
+        xmlns:dc="http://purl.org/dc/elements/1.1/" 
+        xmlns:dcterms="http://purl.org/dc/terms/" 
+        xmlns="http://www.w3.org/2001/XMLSchema" 
+        elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+<import namespace="http://purl.org/dc/elements/1.1/" 
+        schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
+
+<import namespace="http://purl.org/dc/terms/" 
+        schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+
+<element name="dc" type="dul_dc:dul_dcType"/>
+<element name="dcterms" type="dul_dc:dul_dctermsType"/>
+
+<complexType name="dul_dcType">
+  <choice minOccurs="0" maxOccurs="unbounded">
+    <element ref="dc:title"/>
+    <element ref="dc:creator"/>
+    <element ref="dc:subject"/>
+    <element ref="dc:description"/>
+    <element ref="dc:publisher"/>
+    <element ref="dc:contributor"/>
+    <element ref="dc:date"/>
+    <element ref="dc:type"/>
+    <element ref="dc:format"/>
+    <element ref="dc:identifier"/>
+    <element ref="dc:source"/>
+    <element ref="dc:language"/>
+    <element ref="dc:relation"/>
+    <element ref="dc:coverage"/>
+    <element ref="dc:rights"/>
+  </choice>
+</complexType>
+
+<complexType name="dul_dctermsType">
+  <choice minOccurs="0" maxOccurs="unbounded">
+    <element ref="dcterms:alternative"/>
+    <element ref="dcterms:tableOfContents"/>
+    <element ref="dcterms:abstract"/>
+    <element ref="dcterms:created"/>
+    <element ref="dcterms:valid"/>
+    <element ref="dcterms:available"/>
+    <element ref="dcterms:issued"/>
+    <element ref="dcterms:modified"/>
+    <element ref="dcterms:dateAccepted"/>
+    <element ref="dcterms:dateCopyrighted"/>
+    <element ref="dcterms:dateSubmitted"/>
+    <element ref="dcterms:extent"/>
+    <element ref="dcterms:medium"/>
+    <element ref="dcterms:isVersionOf"/>
+    <element ref="dcterms:hasVersion"/>
+    <element ref="dcterms:isReplacedBy"/>
+    <element ref="dcterms:replaces"/>
+    <element ref="dcterms:isRequiredBy"/>
+    <element ref="dcterms:requires"/>
+    <element ref="dcterms:isPartOf"/>
+    <element ref="dcterms:hasPart"/>
+    <element ref="dcterms:isReferencedBy"/>
+    <element ref="dcterms:references"/>
+    <element ref="dcterms:isFormatOf"/>
+    <element ref="dcterms:hasFormat"/>
+    <element ref="dcterms:conformsTo"/>
+    <element ref="dcterms:spatial"/>
+    <element ref="dcterms:temporal"/>
+    <element ref="dcterms:audience"/>
+    <element ref="dcterms:accrualMethod"/>
+    <element ref="dcterms:accrualPeriodicity"/>
+    <element ref="dcterms:accrualPolicy"/>
+    <element ref="dcterms:instructionalMethod"/>
+    <element ref="dcterms:provenance"/>
+    <element ref="dcterms:rightsHolder"/>
+    <element ref="dcterms:mediator"/>
+    <element ref="dcterms:educationLevel"/>
+    <element ref="dcterms:accessRights"/>
+    <element ref="dcterms:license"/>
+    <element ref="dcterms:bibliographicCitation"/>
+  </choice>
+</complexType>
+
+</schema>


### PR DESCRIPTION
Requires an additional configuration file. Copy config/dpla_mapping.yml.sample to config/dpla_mapping.yml and restart the Rails server.

Feed is available for any digital collections item, e.g.:

http://localhost:3000/dc/alexharris/ahpst002028/feed.xml