### PR TITLE
Add convenience methods for nested struct maps

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -62,6 +62,30 @@ class SolrDocument
   def derivative_ids(type='default')
     struct_map_docs(type).map { |doc| doc.local_id }.compact
   end
+
+  
+  # Support for Struct Maps with nested divs
+  # TODO: integrate nested div structure into ddr-models struct_map methods
+
+  def multires_image_file_paths(type='default')
+    nested_docs = nested_struct_map_docs('Images')
+    docs = nested_docs.any? ? nested_docs : struct_map_docs(type)
+    docs.map { |doc| doc.multires_image_file_path }.compact
+  end
+
+  def nested_struct_map_docs(type='default')
+    nested_struct_map_pids(type).map { |pid| self.class.find(pid) }.compact
+  end
+
+  def nested_struct_map_pids(type='default')
+    nested_struct_map(type).map { |d| d['divs'].map { |d| d['fptrs'].first } }.flatten.compact
+  rescue
+    []
+  end
+
+  def nested_struct_map(type='default')
+    struct_map.present? ? struct_map['divs'].select { |d| d['type'] == type }.compact : nil
+  end
   
 
   private

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+RSpec.describe SolrDocument do
+
+  describe "#nested_struct_map" do
+    context "no indexed struct maps" do
+      it "should return nil" do
+        expect(subject.nested_struct_map('default')).to be_nil
+      end
+    end
+    context "indexed nested struct map" do
+      let(:struct_map) do
+        {"type"=>"default", "divs"=>
+          [{"id"=>"dukechapel_dcrst003606-images", "type"=>"Images", "fptrs"=>[], "divs"=>
+            [{"id"=>"dcrst003606001", "order"=>"1", "fptrs"=>["changeme:1030"], "divs"=>[]},
+             {"id"=>"dcrst003606002", "order"=>"2", "fptrs"=>["changeme:1031"], "divs"=>[]},
+             {"id"=>"dcrst003606003", "order"=>"3", "fptrs"=>["changeme:1032"], "divs"=>[]}]},
+           {"id"=>"dukechapel_dcrst003606-documents", "type"=>"Documents", "fptrs"=>[], "divs"=>
+            [{"id"=>"dcrst003606", "order"=>"1", "fptrs"=>["changeme:1029"], "divs"=>[]}]}
+          ]
+        }
+      end
+      before { allow(subject).to receive(:struct_map) { struct_map } }
+      context "nested struct map has documents" do
+        let(:expected_result) { [{"id"=>"dukechapel_dcrst003606-documents", "type"=>"Documents", "fptrs"=>[], "divs"=>[{"id"=>"dcrst003606", "order"=>"1", "fptrs"=>["changeme:1029"], "divs"=>[]}]}] }
+        it "should return the documents portion of the struct map" do
+          expect(subject.nested_struct_map("Documents")).to match(expected_result)
+        end
+      end
+      context "nested struct map is missing requested type" do
+        it "should return an empty array" do
+          expect(subject.nested_struct_map("foo")).to match([])
+        end
+
+      end
+    end
+
+  end
+
+
+  describe "#multires_image_file_paths" do
+    context "no structural metadata" do
+      it "should return an empty array" do
+        expect(subject.multires_image_file_paths).to match([])
+      end
+    end
+    context "structural metadata" do
+      let(:struct_map) do
+        {"type"=>"default", "divs"=>
+          [{"id"=>"viccb010010010", "label"=>"1", "order"=>"1", "type"=>"Image", "fptrs"=>["test:5"], "divs"=>[]},
+           {"id"=>"viccb010020010", "label"=>"2", "order"=>"2", "type"=>"Image", "fptrs"=>["test:6"], "divs"=>[]},
+           {"id"=>"viccb010030010", "label"=>"3", "order"=>"3", "type"=>"Image", "fptrs"=>["test:7"], "divs"=>[]}]
+        }
+      end
+      before { allow(subject).to receive(:struct_map) { struct_map } }
+      context "structural objects with multi-res images" do
+        let(:expected_result) { [ "/path/file1.ptif", "/path/file2.ptif" ] }
+        before do
+          allow(SolrDocument).to receive(:find).with('test:5') { double(multires_image_file_path: "/path/file1.ptif") }
+          allow(SolrDocument).to receive(:find).with('test:6') { double(multires_image_file_path: nil) }
+          allow(SolrDocument).to receive(:find).with('test:7') { double(multires_image_file_path: "/path/file2.ptif") }
+        end
+        it "should return and array of file paths" do
+          expect(subject.multires_image_file_paths).to match(expected_result)
+        end
+      end
+      context "nested structural metadata" do
+        let(:struct_map) do
+          {"type"=>"default", "divs"=>
+            [{"id"=>"dukechapel_dcrst003606-images", "type"=>"Images", "fptrs"=>[], "divs"=>
+              [{"id"=>"dcrst003606001", "order"=>"1", "fptrs"=>["changeme:1030"], "divs"=>[]},
+               {"id"=>"dcrst003606002", "order"=>"2", "fptrs"=>["changeme:1031"], "divs"=>[]},
+               {"id"=>"dcrst003606003", "order"=>"3", "fptrs"=>["changeme:1032"], "divs"=>[]}]},
+             {"id"=>"dukechapel_dcrst003606-documents", "type"=>"Documents", "fptrs"=>[], "divs"=>
+              [{"id"=>"dcrst003606", "order"=>"1", "fptrs"=>["changeme:1029"], "divs"=>[]}]}
+            ]
+          }
+        end
+        before { allow(subject).to receive(:struct_map) { struct_map } }
+        context "nested structural objects with multi-res images" do
+          let(:expected_result) { [ "/path/file1.ptif", "/path/file2.ptif" ] }
+          before do
+            allow(SolrDocument).to receive(:find).with('changeme:1030') { double(multires_image_file_path: "/path/file1.ptif") }
+            allow(SolrDocument).to receive(:find).with('changeme:1031') { double(multires_image_file_path: nil) }
+            allow(SolrDocument).to receive(:find).with('changeme:1032') { double(multires_image_file_path: "/path/file2.ptif") }
+          end
+          it "should return and array of file paths" do
+            expect(subject.multires_image_file_paths).to match(expected_result)
+          end
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This patches the multires_image_file_paths method to also search nested struct maps to support chapel recordings.

A new method -- nested_struct_map_docs() -- can be used to access documents defined in nested structural metadata by type. nested_struct_map_docs("Document") would return all the documents with the type "Document" in the struct map.

This is probably better implemented in ddr-models once we have a clearer idea of how other kinds of nested structural metadata will be formatted.