### PR TITLE
Shrink longer digital collection titles to fit in showcase area. Fixe…

### DIFF
--- a/app/assets/stylesheets/ddr.css.scss
+++ b/app/assets/stylesheets/ddr.css.scss
@@ -230,6 +230,10 @@ body.blacklight-catalog-show #content {
   &.showcase-side {
     height: 500px;
     overflow: auto; 
+
+    & h1.long-title {
+      font-size: floor(($font-size-h1 * 0.86));
+    }
   }
   
   &.collection-submast {

--- a/app/views/digital_collections/_home_showcase.html.erb
+++ b/app/views/digital_collections/_home_showcase.html.erb
@@ -2,7 +2,9 @@
   <div class="container-fluid showcase-wrapper">
     <div class="row no-gutter">
       <div class="col-md-4 collection-start showcase-side">
-        <h1 id="collection-title"><%= t("ddr.public.portal.#{params[:collection] || controller_name}.title", :default => @collection_document.title) %></h1>
+        <h1 id="collection-title"<% if @collection_document.title.length >= 70 %> class="long-title"<% end %>>
+        <%= t("ddr.public.portal.#{params[:collection] || controller_name}.title", :default => @collection_document.title) %>
+        </h1>
         <p class="collection-abstract"><%= @collection_document.abstract %> <%= link_to raw("More&nbsp;&raquo;"), {anchor: "about"}, class: "more-link", title: "Learn more about the collection" %></p>
 
             <%= link_to(params.merge("f[active_fedora_model_ssi][]" => "Item"), :class => "btn btn-primary browse-all") do %>


### PR DESCRIPTION
…s #357 

This sets a threshold at 70 characters; if a title is longer than 70, it'll display at ~38px font-size instead of the normal ~44px for h1.

Of all current digital collections, regardless of platform, only 2-3 exceed 70 and our longest collection name is 79 characters:
`Americans in the Land of Lenin: Documentary Photographs of Early Soviet Russia`

This style adjustment seems to accommodate titles up to around 110, depending on word lengths & length of abstract.