### PR TITLE
revised testing for login-to-download button

### DIFF
--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CatalogHelper do
             'active_fedora_model_ssi'=>'Component',
             'content_size_human_ssim'=>content_size,
             'workflow_state_ssi'=>'published',
-            Ddr::Index::Fields::ACCESS_ROLE=>"{}",
+            Ddr::Index::Fields::ACCESS_ROLE=>"{}", 'object_profile_ssm'=>['{"datastreams":{"content":{"dsLabel":"image10.tif","dsVersionID":"content.0","dsCreateDate":"2014-10-22T17:30:02Z","dsState":"A","dsMIME":"image/tiff","dsFormatURI":null,"dsControlGroup":"M","dsSize":69742260,"dsVersionable":true,"dsInfoType":null,"dsLocation":"changeme:10+content+content.0","dsLocationType":"INTERNAL_ID","dsChecksumType":"SHA-256","dsChecksum":"b9eb20b6fb4a27d6bf478bdefb25538bea95740bdf48471ec360d25af622a911"}}}'],
             'attached_files_ss'=>['{"thumbnail":{"size":14992},"content":{"size":24330280},"extractedText":{"size":null},"fits":{"size":4797}}']
             ) }
 
@@ -39,12 +39,9 @@ RSpec.describe CatalogHelper do
           allow(helper).to receive(:user_signed_in?) { false }
           allow(document).to receive(:roles) { role_set }
         end
-        context "and the 'registered' group has the 'downloader' role" do
-          before { role_set.roles= downloader_role }
-          it "should render a 'login to download' button" do
-            expect(helper).to receive(:render).with(hash_including(partial: "download_restricted"))
-            helper.file_info(document: document)
-          end
+        it "should render a login-to-download button" do
+          expect(helper).to receive(:render).with(hash_including(partial: "download_restricted"))
+          helper.file_info(document: document)
         end
       end
     end


### PR DESCRIPTION
AFAIK the 'Registered' group didn't end up being a usable distinction for when to render which buttons, so it's irrelevant in the tests. Any logged-out users encountering a file where Public agent doesn't have Downloader role will get the "Login to Download" button; if they click it and log in, then they will get either the green download button (if their account is permitted) or the red Not Authorized button (if their account isn't). See discussion thread on #236