### PR TITLE
add :apply_gated_discovery and :include_only_published to processor chain

### DIFF
--- a/app/controllers/concerns/ddr/public/controller/portal_setup.rb
+++ b/app/controllers/concerns/ddr/public/controller/portal_setup.rb
@@ -25,7 +25,7 @@ module Ddr
         end
 
         def portal_controller_setup
-          portal_controller_setup ||= Portal::ControllerSetup.new({ controller_name: controller_name, local_id: params[:collection] })
+          portal_controller_setup ||= Portal::ControllerSetup.new({ controller_name: controller_name, local_id: params[:collection], current_ability: current_ability })
         end
 
       end

--- a/app/controllers/digital_collections_controller.rb
+++ b/app/controllers/digital_collections_controller.rb
@@ -55,9 +55,8 @@ class DigitalCollectionsController < CatalogController
   private
 
   def digital_collections_portal
-    @portal = Portal::DigitalCollections.new({ controller_name: controller_name, local_id: params[:collection] })
+    @portal = Portal::DigitalCollections.new({ controller_name: controller_name, local_id: params[:collection], current_ability: current_ability })
   end
-
 
 
   #TODO: Put into a concern or something?


### PR DESCRIPTION
Fixes issue where item and collection counts are incorrect because they do not account for the user's current role (i.e. gated discovery).