### PR TITLE
Add timeouts and error handling to external service requests

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,8 +37,11 @@ module ApplicationHelper
   def ead_id_title(code)
     Rails.cache.fetch("#{code}/ead_id_title", expires_in: 7.days) do
       begin
-        Ddr::Models::FindingAid.new(code).collection_title
-      rescue OpenURI::HTTPError
+        Timeout.timeout(2) do
+          Ddr::Models::FindingAid.new(code).collection_title
+        end
+      rescue OpenURI::HTTPError, Timeout::Error => e
+        Rails.logger.error { "#{e.message} #{e.backtrace.join("\n")}" }
         code
       end
     end

--- a/app/helpers/metadata_display_helper.rb
+++ b/app/helpers/metadata_display_helper.rb
@@ -32,20 +32,22 @@ module MetadataDisplayHelper
   end
 
   def source_collection options={}
+    document = options[:document]
+    placement = options[:placement] ? options[:placement] : 'top'
     begin
-      finding_aid = options[:document].finding_aid
-      link_to finding_aid.collection_title, finding_aid.url, { data: {
-        toggle: 'popover',
-        placement: options[:placement] ? options[:placement] : 'top',
-        html: true,
-        title: ''+ image_tag("ddr/archival-box.png", :class=>"collection-guide-icon") + 'Source Collection Guide',
-        content: finding_aid_popover(finding_aid)
-      }}
-
+      Rails.cache.fetch("source_collection_#{document.pid}_#{placement}", expires_in: 7.days) do
+        finding_aid = document.finding_aid
+        link_to finding_aid.collection_title, finding_aid.url, { data: {
+          toggle: 'popover',
+          placement: placement,
+          html: true,
+          title: ''+ image_tag("ddr/archival-box.png", :class=>"collection-guide-icon") + 'Source Collection Guide',
+          content: finding_aid_popover(finding_aid)
+        }}
+      end
     rescue OpenURI::HTTPError => e
       Rails.logger.error { "#{e.message} #{e.backtrace.join("\n")}" }
-      fallback_link = link_to "Search Collection Guides", "http://library.duke.edu/rubenstein/findingaids/"
-      "<p class='small'>" + fallback_link + "</p>"
+      link_to "Search Collection Guides", "http://library.duke.edu/rubenstein/findingaids/"
     end
   end
 

--- a/app/views/catalog/_show_finding_aid.html.erb
+++ b/app/views/catalog/_show_finding_aid.html.erb
@@ -1,11 +1,11 @@
-<% unless document.finding_aid.blank? %>
+<% finding_aid = get_finding_aid(document) %>
+
+<% if finding_aid.present? %>
   <div class="finding_aid buffer-bottom-40">
     <div class="text-muted text-uppercase small strong">Source Collection</div>
-      <% cache("finding_aid_brief_#{document.ead_id}", expires_in: 7.days) do %>
-        <%= source_collection({ :document => document, :placement => 'left' })  %>
-      <% end %>
+      <%= source_collection({ :document => document, :placement => 'left' })  %>
       <% unless document.aspace_id.blank? %>
-        <p><a href="<%= document.finding_aid.url %>#aspace_<%= document.aspace_id %>" class="text-muted small">View Item in Context</a></p>
+        <p><a href="<%= finding_aid.url %>#aspace_<%= document.aspace_id %>" class="text-muted small">View Item in Context</a></p>
       <% end %>
   </div>
 <% end %>

--- a/app/views/catalog/_show_finding_aid_full.html.erb
+++ b/app/views/catalog/_show_finding_aid_full.html.erb
@@ -1,5 +1,5 @@
 <% cache("finding_aid_full_#{document.ead_id}", expires_in: 7.days) do %>
-  <% finding_aid = document.finding_aid %>
+  <% finding_aid = get_finding_aid(document) %>
   <% if finding_aid.present? %>
 
   <div class="well well-md" id="source-collection">

--- a/app/views/catalog/_show_research_help.html.erb
+++ b/app/views/catalog/_show_research_help.html.erb
@@ -1,5 +1,5 @@
 <% cache("show_research_help_#{document.id}", expires_in: 7.days) do %>
-  <% research_help = document.research_help %>
+  <% research_help = get_research_help(document) %>
   <% if research_help %>
   <div class="buffer-bottom-40">
     <h4><span class="contact-devil-logo"></span><%= research_help_title(research_help) %></h4>


### PR DESCRIPTION
This makes the requests to get finding aid and contact info more resilient to request failures and slow responses.