### PR TITLE
Make long metadata values with no spaces (like permalink) wrap if lon…

### DIFF
--- a/app/assets/stylesheets/ddr.css.scss
+++ b/app/assets/stylesheets/ddr.css.scss
@@ -644,6 +644,10 @@ image-based items */
 
 }
 
+dl.document-metadata {
+  overflow-wrap: break-word;
+}
+
 
 /* Special style overrides for collections results section */
 


### PR DESCRIPTION
…ger than their container. Fixes #461