### PR TITLE
Add auto_link_values helper method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'fastimage'
 gem 'bootstrap-select-rails'
 gem 'nokogiri'
 gem 'edtf-humanize', '~> 0.0.7'
+gem 'rails_autolink'
 
 gem 'sdoc', '~> 0.4.0', group: :doc
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,6 +303,8 @@ GEM
       sprockets-rails (~> 2.0)
     rails-observers (0.1.2)
       activemodel (~> 4.0)
+    rails_autolink (1.1.6)
+      rails (> 3.1)
     railties (4.1.14.1)
       actionpack (= 4.1.14.1)
       activesupport (= 4.1.14.1)
@@ -506,6 +508,7 @@ DEPENDENCIES
   orderly
   prawn
   rails (~> 4.1.13)
+  rails_autolink
   rspec-rails (~> 3.4)
   rubyzip (~> 1.1.7)
   sass-rails (~> 5.0.4)

--- a/app/helpers/metadata_display_helper.rb
+++ b/app/helpers/metadata_display_helper.rb
@@ -60,5 +60,9 @@ module MetadataDisplayHelper
     display.join("; ")
   end
 
+  def auto_link_values options={}
+    options[:value].map { |value| auto_link(value) }
+  end
+
 
 end

--- a/spec/helpers/metadata_display_helper_spec.rb
+++ b/spec/helpers/metadata_display_helper_spec.rb
@@ -54,4 +54,14 @@ RSpec.describe MetadataDisplayHelper do
     end
   end
 
+  describe "#auto_link_values" do
+    let (:display_strings_with_links) {["<a href=\"https://library.duke.edu\">https://library.duke.edu</a>", "this is not a link"]}
+    context "field contains some values should be linked and some that should not be linked" do
+      let (:metadata_field_values) {['https://library.duke.edu', 'this is not a link']}
+      it "should return a semicolon delimited list of values, the first of which is a link" do
+        expect(helper.auto_link_values({:value => metadata_field_values})).to match(display_strings_with_links)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This auto_link_values helper method can be used to create links from dc.relation (or other) field values.