### PR TITLE
Patches RSolr to use .solr_escape for .escape

### DIFF
--- a/config/initializers/rsolr_monkey_patches.rb
+++ b/config/initializers/rsolr_monkey_patches.rb
@@ -1,0 +1,7 @@
+require 'rsolr'
+
+module RSolr
+  def self.escape(*args)
+    solr_escape(*args)
+  end
+end


### PR DESCRIPTION
Effectively squashes deprecation warnings.