### PR TITLE
Forces a sign_out if user is signed in and Shib is required but there is no Shib session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,10 +4,14 @@ class ApplicationController < ActionController::Base
   before_filter { ApplicationController.current = self }
   after_filter  { ApplicationController.current = nil  }
 
+  before_action :sign_out,
+                if: [:user_signed_in?, "Ddr::Auth.require_shib_user_authn"],
+                unless: :shib_session?
+
   helper Openseadragon::OpenseadragonHelper
   # Adds a few additional behaviors into the application controller
-   include Blacklight::Controller
-   include Ddr::Auth::RoleBasedAccessControlsEnforcement
+  include Blacklight::Controller
+  include Ddr::Auth::RoleBasedAccessControlsEnforcement
 
   # Please be sure to impelement current_user and user_session. Blacklight depends on
   # these methods in order to perform user specific actions.
@@ -17,5 +21,10 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  def shib_session?
+    # This is how omniauth-shibboleth checks for a Shib session
+    request.env['Shib-Session-ID'] || request.env['Shib-Application-ID']
+  end
 
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+
+  let(:user) { FactoryGirl.create(:user) }
+
+  controller do
+    def index
+      render nothing: true
+    end
+  end
+
+  describe "when the user is signed in" do
+    before { sign_in user }
+    describe "and Shib authn is required" do
+      before {
+        allow(Ddr::Auth).to receive(:require_shib_user_authn) { true }
+      }
+      describe "and there is no Shib session" do
+        before {
+          allow(controller).to receive(:shib_session?) { false }
+        }
+        it "signs the user out" do
+          expect(controller).to receive(:sign_out)
+          get :index
+        end
+      end
+      describe "and there is a Shib session" do
+        before {
+          allow(controller).to receive(:shib_session?) { true }
+        }
+        it "does not sign the user out" do
+          expect(controller).not_to receive(:sign_out)
+          get :index
+        end
+      end
+    end
+    describe "and Shib authn is not required" do
+      before {
+        allow(Ddr::Auth).to receive(:require_shib_user_authn) { false }
+      }
+      describe "and there is no Shib session" do
+        before {
+          allow(controller).to receive(:shib_session?) { false }
+        }
+        it "does not sign the user out" do
+          expect(controller).not_to receive(:sign_out)
+          get :index
+        end
+      end
+      describe "and there is a Shib session" do
+        before {
+          allow(controller).to receive(:shib_session?) { true }
+        }
+        it "does not sign the user out" do
+          expect(controller).not_to receive(:sign_out)
+          get :index
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This addresses DDR-287 in which an application session can remain active although the
Shibboleth session has expired.