### PR TITLE
Display item record even if multires image doesn't exist

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -14,8 +14,8 @@ module CatalogHelper
     document[:active_fedora_model_ssi] == "Collection"
   end
 
-  def is_multi_image? document
-    document.multires_image_file_paths.length > 1
+  def has_two_or_more_multires_images? document
+    document.multires_image_file_paths.present? && document.multires_image_file_paths.length > 1
   end
 
   # Facet field view helper

--- a/app/views/catalog/_display_multi_image.html.erb
+++ b/app/views/catalog/_display_multi_image.html.erb
@@ -1,43 +1,46 @@
 <% cache("display_multi_image_#{params[:collection]}_#{params[:id]}", expires_in: 7.days) do %>
 
-  <%# default partial to display solr document fields in catalog show view -%>
+  <% if @document.multires_image_file_paths.present? %>
 
-  <%# --------------------------- %>
-  <%#   Multi-Page / Multi-Image  %>
-  <%# --------------------------- %>
+    <%# default partial to display solr document fields in catalog show view -%>
 
-  <% if is_multi_image?(@document) %>
+    <%# --------------------------- %>
+    <%#   Multi-Page / Multi-Image  %>
+    <%# --------------------------- %>
 
-    <%# For search engine indexing & graceful degradation, %>
-    <%# show the first image in <img> and make links to the rest %>
-    <noscript>
-      <%= render partial: "show_image_derivative", locals: { image_path: document.first_multires_image_file_path } %>
+    <% if has_two_or_more_multires_images?(@document) %>
 
-      <h3>Images for this Item</h3>
-      <ul>
-        <% document.multires_image_file_paths.each do |path| %>
-          <% unless path.blank? %>
-            <li><%= link_to File.basename(path, File.extname(path)), iiif_image_path(path, {:size => '!850,850'}) %></li>
+      <%# For search engine indexing & graceful degradation, %>
+      <%# show the first image in <img> and make links to the rest %>
+      <noscript>
+        <%= render partial: "show_image_derivative", locals: { image_path: document.first_multires_image_file_path } %>
+
+        <h3>Images for this Item</h3>
+        <ul>
+          <% document.multires_image_file_paths.each do |path| %>
+            <% unless path.blank? %>
+              <li><%= link_to File.basename(path, File.extname(path)), iiif_image_path(path, {:size => '!850,850'}) %></li>
+            <% end %>
           <% end %>
-        <% end %>
-      </ul>
-    </noscript>
+        </ul>
+      </noscript>
 
-    <%# Make the array of page image paths accessible to JS for use by the download buttons %>
-    <%= javascript_tag do %>
-      var pagepaths = <%= raw document.multires_image_file_paths.to_json %>;
+      <%# Make the array of page image paths accessible to JS for use by the download buttons %>
+      <%= javascript_tag do %>
+        var pagepaths = <%= raw document.multires_image_file_paths.to_json %>;
+      <% end %>
     <% end %>
 
-  <% end %>
+    <%# ------------------------------------ %>
+    <%#   Multi-Res (Has One or More PTIFs)  %>
+    <%# ------------------------------------ %>
 
-  <%# ------------------------------------ %>
-  <%#   Multi-Res (Has One or More PTIFs)  %>
-  <%# ------------------------------------ %>
+    <% if tilesources = image_item_tilesources(document.multires_image_file_paths) %>
 
-  <% if tilesources = image_item_tilesources(document.multires_image_file_paths) %>
+      <%= render partial: "item_options", locals: { image_path: document.first_multires_image_file_path, imagecount: tilesources.length } %>
+      <%= render partial: "show_seadragon", locals: { aspectratio: image_item_aspectratio(document.multires_image_file_paths), imagecount: tilesources.length } %>
 
-    <%= render partial: "item_options", locals: { image_path: document.first_multires_image_file_path, imagecount: tilesources.length } %>
-    <%= render partial: "show_seadragon", locals: { aspectratio: image_item_aspectratio(document.multires_image_file_paths), imagecount: tilesources.length } %>
+    <% end %>
 
   <% end %>
 

--- a/app/views/catalog/_item_options_download_multi_image.html.erb
+++ b/app/views/catalog/_item_options_download_multi_image.html.erb
@@ -1,4 +1,4 @@
-<% if is_multi_image?(@document) %>
+<% if has_two_or_more_multires_images?(@document) %>
   <li class="dropdown-header">All Images <span class="text-muted">(<%= imagecount %>)</span></li>
 
   <li><%= multi_image_download_button(@document, { label: "PDF", action: "pdf_images" }) %></li>

--- a/app/views/catalog/_show_seadragon.html.erb
+++ b/app/views/catalog/_show_seadragon.html.erb
@@ -5,7 +5,7 @@ We may want to refactor into separate partials. %>
   <div id="image-toolbar">
     <div id="image-toolbar-inner">
 
-    <% if is_item?(@document) && is_multi_image?(@document) %>
+    <% if is_item?(@document) && has_two_or_more_multires_images?(@document) %>
       <div class="multi-image-nav">
         <button id="btn-prev" class="seadragon-prevnext btn" type="button"><span class="btn-wrapper" data-toggle="tooltip" data-placement="bottom" title="Prev" aria-label="Prev"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span></button>
         <button id="btn-next" class="seadragon-prevnext btn" type="button"><span class="btn-wrapper" data-toggle="tooltip" data-placement="bottom" title="Next" aria-label="Next"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></span></button>
@@ -71,7 +71,7 @@ $(document).ready(function(e){
   <% elsif is_component?(@document) %>
     tileSources: <%= image_component_tilesource(@document).to_json.html_safe %>,
   <% end %>
-  <% if is_item?(@document) && is_multi_image?(@document) %>
+  <% if is_item?(@document) && has_two_or_more_multires_images?(@document) %>
     sequenceMode: true,
     showReferenceStrip:  true,
     referenceStripScroll: 'vertical',

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -5,6 +5,35 @@ RSpec.describe CatalogHelper do
   let(:content_size) { "66.5 MB" }
   let(:permanent_url) { "http://id.library.duke.edu/ark:/99999/fk4zzz" }
 
+  describe "#has_two_or_more_multires_images?" do
+    let(:document) { SolrDocument.new(
+                'id'=>'changeme:10',
+                ) }
+    before { allow(document).to receive(:multires_image_file_paths) { file_paths } }
+
+    context "document does not have any multires images" do
+      let(:file_paths) {}
+      it "should return false" do
+        expect(helper.has_two_or_more_multires_images?(document)).to be_falsey
+      end
+    end
+
+    context "document has a single multires image" do
+      let(:file_paths) { ['path/to/image/1'] }
+      it "should return false" do
+        expect(helper.has_two_or_more_multires_images?(document)).to be_falsey
+      end
+    end
+
+    context "document has two multires images" do
+      let(:file_paths) { ['path/to/image/1', 'path/to/image/2'] }
+      it "should return true" do
+        expect(helper.has_two_or_more_multires_images?(document)).to be_truthy
+      end
+    end
+
+  end
+
   describe "#file_info" do
     let(:document) { SolrDocument.new(
             'id'=>'changeme:10',


### PR DESCRIPTION
I renamed the is_multi_image? helper method to has_two_or_more_multires_images? and added a test to clarify the purpose of the method.