### PR TITLE
Fix error when doc not found

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -347,12 +347,20 @@ class CatalogController < ApplicationController
     render :file => "#{Rails.root}/public/403", :formats => [:html], :status => 403, :layout => false
   end
 
+  def not_found
+    render file: "#{Rails.root}/public/404", status: 404, layout: false
+  end
+
   def authentication_required?
     Ddr::Public.require_authentication
   end
 
   def enforce_show_permissions
-    authorize! :read, params[:id]
+    begin
+      authorize! :read, params[:id]
+    rescue SolrDocument::NotFound
+      not_found
+    end
   end
 
 

--- a/app/controllers/digital_collections_controller.rb
+++ b/app/controllers/digital_collections_controller.rb
@@ -72,16 +72,16 @@ class DigitalCollectionsController < CatalogController
 
   def authorize_portal_page
     if @document_list.blank? && user_signed_in?
-      forbidden
+      not_found
     elsif @document_list.blank?
       authenticate_user!
     end
   end
 
   def set_params_id_to_pid
-    result = ActiveFedora::SolrService.query(local_id_query, rows: 1).first
-    document = SolrDocument.new result
-    unless document.nil?
+    result = ActiveFedora::SolrService.query(local_id_query, rows: 1)
+    unless result.blank?
+      document = SolrDocument.new result.first
       params[:id] = document.id
     end
   end


### PR DESCRIPTION
Also, now returns 404 instead of 403 if someone tries to go to a collection portal page that doesn't exist.