### PR TITLE
Add support for isFormatOf item relationships

### DIFF
--- a/app/models/related_item.rb
+++ b/app/models/related_item.rb
@@ -1,87 +1,27 @@
 class RelatedItem
 
-  include Blacklight::Configurable
-  include Blacklight::SearchHelper
-  include Ddr::Public::Controller::SolrQueryConstructor
+  extend Forwardable
 
-  attr_accessor :document,
-                :config,
-                :related_documents,
-                :name,
-                :solr_field,
-                :solr_values,
-                :solr_params
+  def_delegators :@related_item,
+                 :name,
+                 :related_documents,
+                 :solr_query
 
   def initialize args={}
-    @document   = args[:document]
-    @config     = args[:config]
-    @name       = relation_name
-    @solr_field = solr_field_name
-  end
-
-  def solr_values
-    @values ||= Hash[*facet_values_and_counts].keys
-  end
-
-  def related_documents
-    @rel_docs ||= title_sorted_documents
-  end
-
-  def solr_params
-    {"f" => {@solr_field => self.solr_values}, "sort" => "#{Ddr::Index::Fields::TITLE} asc"}
+    @document     = args[:document]
+    @config       = args[:config]
+    @related_item = related_item_class.new({ document: @document, config: @config })
   end
 
 
   private
 
-  def title_sorted_documents
-    delete_self.sort { |a,b| a.title <=> b.title }
-  end
-
-  def delete_self
-    remove_duplicates.delete_if { |doc| doc.id == @document.id }
-  end
-
-  def remove_duplicates
-    related_documents_results.flatten.uniq { |doc| doc.id }
-  end
-
-  def related_documents_results
-    self.solr_values.map do |value|
-      relator_field_query(@solr_field, value)
-    end
-  end
-
-  def relation_name
-    @config["name"]
-  end
-
-  def solr_field_name
-    constantize_solr_field_name({solr_field: @config["field"]})
-  end
-
-  def relator_field_query relator_field, value
-    query = construct_query(relator_field => value)
-    response = repository.search(search_builder.where(query))
-    response.documents
-  end
-
-  def facet_values_and_counts
-    query = ActiveFedora::SolrService.construct_query_for_pids([@document.id])
-    response = repository.search(searcher.where(query).merge({fl: "id", 'facet.field' => @solr_field}))
-    response['facet_counts']['facet_fields'][@solr_field]
-  end
-
-  def searcher
-    if document.controller_scope
-      @search_builder ||= SearchBuilder.new(query_processor_chain, document.controller_scope)
+  def related_item_class
+    if @config.has_key?('id_field')
+      RelatedItem::IdReference
     else
-      search_builder
+      RelatedItem::SharedValue
     end
-  end
-
-  def query_processor_chain
-    [:add_query_to_solr, :apply_access_controls, :include_only_published]
   end
 
 end

--- a/app/models/related_item/id_reference.rb
+++ b/app/models/related_item/id_reference.rb
@@ -1,0 +1,35 @@
+class RelatedItem::IdReference
+
+  include RelatedItem::RelatedItemBehavior
+
+
+  private
+
+  def solr_field_name
+    constantize_solr_field_name({solr_field: @config["field"]})
+  end
+
+  def solr_query_field
+    constantize_solr_field_name({solr_field: @config["id_field"]})
+  end
+
+  def solr_query_values
+    "\"#{document_field_values.join(' OR ')}\"" if document_field_values.present?
+  end
+
+  def title_sorted_documents
+    if document_field_values.present?
+      response = repository.search(search_builder.where(id_field_query).merge(sort: sort))
+      response.documents
+    end
+  end
+
+  def id_field_query
+    construct_query(field_value_pairs(solr_query_field, document_field_values), 'OR')
+  end
+
+  def document_field_values
+    @document[solr_field_name]
+  end
+
+end

--- a/app/models/related_item/related_item_behavior.rb
+++ b/app/models/related_item/related_item_behavior.rb
@@ -1,0 +1,48 @@
+module RelatedItem::RelatedItemBehavior
+
+  extend ActiveSupport::Concern
+
+  included do
+    include Blacklight::Configurable
+    include Blacklight::SearchHelper
+    include Ddr::Public::Controller::SolrQueryConstructor
+  end
+
+
+  def initialize args={}
+    @document = args[:document]
+    @config   = args[:config]
+  end
+
+  def name
+    @config["name"]
+  end
+
+  def related_documents
+    @rel_docs ||= title_sorted_documents
+  end
+
+  def solr_query
+    {"f" => { solr_query_field => solr_query_values }, "sort" => sort} if solr_query_values.present?
+  end
+
+
+  private
+
+  def sort
+    "#{Ddr::Index::Fields::TITLE} asc"
+  end
+
+  def searcher
+    if @document.controller_scope
+      @search_builder ||= SearchBuilder.new(query_processor_chain, @document.controller_scope)
+    else
+      search_builder
+    end
+  end
+
+  def query_processor_chain
+    [:add_query_to_solr, :apply_access_controls, :include_only_published]
+  end
+
+end

--- a/app/models/related_item/shared_value.rb
+++ b/app/models/related_item/shared_value.rb
@@ -1,0 +1,46 @@
+class RelatedItem::SharedValue
+
+  include RelatedItem::RelatedItemBehavior
+
+
+  private
+
+  def solr_query_field
+    constantize_solr_field_name({solr_field: @config["field"]})
+  end
+
+  def solr_query_values
+    @values ||= Hash[*facet_values_and_counts].keys
+  end
+
+  def title_sorted_documents
+    delete_self.sort { |a,b| a.title <=> b.title }
+  end
+
+  def delete_self
+    remove_duplicates.delete_if { |doc| doc.id == @document.id }
+  end
+
+  def remove_duplicates
+    related_documents_results.flatten.uniq { |doc| doc.id }
+  end
+
+  def related_documents_results
+    solr_query_values.map do |value|
+      relator_field_query(solr_query_field, value)
+    end
+  end
+
+  def relator_field_query relator_field, value
+    query = construct_query(relator_field => value)
+    response = repository.search(search_builder.where(query))
+    response.documents
+  end
+
+  def facet_values_and_counts
+    query = ActiveFedora::SolrService.construct_query_for_pids([@document.id])
+    response = repository.search(searcher.where(query).merge({fl: "id", 'facet.field' => solr_query_field}))
+    response['facet_counts']['facet_fields'][solr_query_field]
+  end
+
+end

--- a/app/views/catalog/_related_items.html.erb
+++ b/app/views/catalog/_related_items.html.erb
@@ -2,13 +2,13 @@
   <% @document.related_items.each do |related_item| %>
     <% if related_item.related_documents.present? %>
       <% if related_item.related_documents.count > 3 %>
-        <h3><%= link_to("#{related_item.name} (#{related_item.related_documents.count + 1 })", search_action_path(related_item.solr_params)) %></h3>
+        <h3><%= link_to("#{related_item.name} (#{related_item.related_documents.count + 1 })", search_action_path(related_item.solr_query)) %></h3>
       <% else %>
         <h3><%= related_item.name %></h3>
       <% end %>
       <%= render_document_index_with_view("gallery", related_item.related_documents[0..2]) %>
       <% if related_item.related_documents.count > 3 %>
-        <%= link_to("See all #{related_item.related_documents.count + 1} #{related_item.name.pluralize}", search_action_path(related_item.solr_params)) %>
+        <%= link_to("See all #{related_item.related_documents.count + 1} #{related_item.name.pluralize}", search_action_path(related_item.solr_query)) %>
       <% end %>
     <% end %>
   <% end %>

--- a/spec/models/related_item/id_reference_spec.rb
+++ b/spec/models/related_item/id_reference_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe RelatedItem::IdReference do
+
+  let(:doc1) { SolrDocument.new('id' => 'changeme:1', 'title' => 'A') }
+  let(:doc2) { SolrDocument.new('id' => 'changeme:2', 'title' => 'B') }
+  let(:doc3) { SolrDocument.new('id' => 'changeme:3', 'title' => 'C') }
+  let(:docs_list) { [doc1, doc2, doc3] }
+  let(:config) { {"name"=>"Related Items", "field"=>[:series_facet, :facetable], "id_field"=>[:permanent_id, :stored_sortable]} }
+  let(:values) { ["ark:/99999/1111", "ark:/99999/2222"] }
+
+  subject { described_class.new({document: doc1, config: config}) }
+
+  before do
+    allow(subject).to receive(:document_field_values) { values }
+    allow(subject).to receive(:title_sorted_documents) { docs_list }
+  end
+
+  its(:name) { is_expected.to eq("Related Items") }
+  its(:related_documents) { is_expected.to eq([doc1, doc2, doc3]) }
+  its(:solr_query) { is_expected.to eq({"f"=>{"permanent_id_ssi"=>"\"ark:/99999/1111 OR ark:/99999/2222\""}, "sort"=>"title_ssi asc"}) }
+end

--- a/spec/models/related_item/shared_value_spec.rb
+++ b/spec/models/related_item/shared_value_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe RelatedItem do
+RSpec.describe RelatedItem::SharedValue do
 
   let(:doc1) { SolrDocument.new('id' => 'changeme:1', 'title' => 'A') }
   let(:doc2) { SolrDocument.new('id' => 'changeme:2', 'title' => 'B') }
@@ -11,14 +11,12 @@ RSpec.describe RelatedItem do
 
   subject { described_class.new({document: doc1, config: config}) }
 
-    before do
-      allow(subject).to receive(:facet_values_and_counts) { facet_vals_counts }
-      allow(subject).to receive(:relator_field_query) { docs_list }
-    end
+  before do
+    allow(subject).to receive(:facet_values_and_counts) { facet_vals_counts }
+    allow(subject).to receive(:relator_field_query) { docs_list }
+  end
 
   its(:name) { is_expected.to eq("Related Items") }
-  its(:solr_field) { is_expected.to eq("series_facet_sim")}
-  its(:solr_values) { is_expected.to eq(["West Campus", "SNCC and Civil Rights Movement"])}
-  its(:solr_params) { is_expected.to eq({"f" => {"series_facet_sim" => ["West Campus", "SNCC and Civil Rights Movement"]}, "sort"=>"title_ssi asc"}) }
   its(:related_documents) { is_expected.to eq([doc2, doc3]) }
+  its(:solr_query) { is_expected.to eq({"f" => {"series_facet_sim" => ["West Campus", "SNCC and Civil Rights Movement"]}, "sort"=>"title_ssi asc"}) }
 end


### PR DESCRIPTION
For a regular shared facet value relationship (such as series values as used by Duke Chapel) use the first configuration. For an ID pointer relationship add the id_field to the item_relators configuration (will be used for Radio Haiti). In this example the isFormatOf field will reference the arks of any related items in the permanent_id field.

```
item_relators:
  - name: "Related Items"
    field:
      - :series_facet
      - :facetable
  - name: "Other Versions"
    field:
      - :isFormatOf
      - :symbol
    id_field:
      - :permanent_id
      - :stored_sortable
```