### PR TITLE
Structural metadata upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'blacklight', '~> 5.16'
 gem 'hydra-head', '~> 7.2.0'
 gem 'ddr-alerts', git: 'https://github.com/duke-libraries/ddr-alerts', ref: '01408a82f13292b655b3c561688cf824cbd14549'
 gem 'devise' # must be explicitly required
-gem 'ddr-models', git: 'https://github.com/duke-libraries/ddr-models', ref: 'e0ed623a3722ca9583f2531f97dd5f20c126293d'
+gem 'ddr-models', git: 'https://github.com/duke-libraries/ddr-models', ref: '2d6004419e4584d3b82b4d2d1d3f486fc0ea70f6'
 
 gem 'log4r'
 gem 'bootstrap-sass', '~> 3.3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/duke-libraries/ddr-models
-  revision: e0ed623a3722ca9583f2531f97dd5f20c126293d
-  ref: e0ed623a3722ca9583f2531f97dd5f20c126293d
+  revision: 2d6004419e4584d3b82b4d2d1d3f486fc0ea70f6
+  ref: 2d6004419e4584d3b82b4d2d1d3f486fc0ea70f6
   specs:
-    ddr-models (2.6.post)
+    ddr-models (2.7.0.pre)
       active-fedora (~> 7.0)
       activeresource
       cancancan (~> 1.12)
@@ -302,7 +302,7 @@ GEM
       activesupport
       nokogiri (>= 1.4.2)
       solrizer (~> 3.3)
-    omniauth (1.3.1)
+    omniauth (1.4.2)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
     omniauth-shibboleth (1.2.1)
@@ -404,13 +404,13 @@ GEM
     rdf-xsd (1.99.0)
       rdf (~> 1.99)
     rdoc (4.3.0)
-    redis (3.3.2)
+    redis (3.3.3)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     ref (2.0.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
-    resque (1.26.0)
+    resque (1.27.1)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.3)
@@ -467,7 +467,7 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    sinatra (1.4.7)
+    sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -8,6 +8,14 @@ class SolrDocument
 
   include Ddr::Models::SolrDocument
 
+  extend Forwardable
+
+  def_delegators :structures,
+                 :derivative_ids,
+                 :multires_image_file_paths,
+                 :first_multires_image_file_path,
+                 :ordered_component_docs
+
   # self.unique_key = 'id'
 
   # Email uses the semantic field mappings below to generate the body of an email.
@@ -97,28 +105,10 @@ class SolrDocument
     end
   end
 
-
-  # This assumes that the derivative IDs are the local_ids of an item's components
-  def derivative_ids(type='default')
-    ordered_component_docs(type).map { |doc| doc.local_id }.compact
+  def structures
+    @structures ||= Structure.new(structure: self.structure, id: self.id)
   end
 
-  def multires_image_file_paths
-    @multires_image_file_paths ||= find_multires_image_file_paths
-  end
-
-  def first_multires_image_file_path
-    @first_multires_image_file_path ||= find_first_multires_image_file_path
-  end
-
-
-  def ordered_component_pids(type='default')
-    [struct_map_ordered_pids(type), local_id_order_component_pids].find { |val| val.present? }
-  end
-
-  def ordered_component_docs(type='default')
-    [struct_map_ordered_docs(type), local_id_order_component_docs].find { |val| val.present? }
-  end
 
   private
 
@@ -130,89 +120,6 @@ class SolrDocument
 
   def max_download
     portal_view_config.try(:[], 'restrictions').try(:[], 'max_download')
-  end
-
-  def find_multires_image_file_paths
-    docs = ordered_component_docs('Images')
-    if docs.present?
-      docs.map { |doc| doc.multires_image_file_path }.compact
-    else
-      nil
-    end
-  end
-
-  def find_first_multires_image_file_path
-    pids = ordered_component_pids('Images')
-    if pids.present?
-      self.class.find(pids.first).multires_image_file_path
-    else
-      nil
-    end
-  end
-
-  def struct_map_ordered_docs(type='default')
-    pids = struct_map_ordered_pids(type)
-    ordered_documents(pids) if pids.present?
-  end
-
-  def struct_map_ordered_pids(type='default')
-    if struct_map.present?
-      fptrs.any? ? fptrs : nested_fprts(type)
-    end
-  end
-
-  def nested_fprts(type='default')
-    type_div = struct_map['divs'].select { |div| div['type'] == type }.first || {}
-    if type_div.any?
-      type_div['divs'].map { |div| div['fptrs'] }.flatten.compact
-    end
-  end
-
-  def fptrs
-    struct_map['divs'].map { |div| div['fptrs'] }.flatten.compact
-  end
-
-  def local_id_order_component_pids
-    local_id_order_component_docs.map(&:id) if components.present?
-  end
-
-  def local_id_order_component_docs
-    components.sort { |a,b| a.local_id.to_s <=> b.local_id.to_s } if components.present?
-  end
-
-  def ordered_documents(pids)
-    solr_documents = response_to_solr_docs(pids)
-    pids.map{ |pid| solr_documents.find{ |doc| doc["id"] == pid } }
-  end
-
-  def response_to_solr_docs(pids)
-    merged_response_docs(pids).map { |doc| SolrDocument.new(doc) }
-  end
-
-  def merged_response_docs(pids)
-    pids_searches(pids).map { |response| response['response']['docs']}.flatten
-  end
-
-  def pids_searches(pids)
-    pids_queries(pids).map { |query| pids_search(query) }
-  end
-
-  def pids_queries(pids)
-    sliced_pids(pids).map { |pids| pids_query(pids) }
-  end
-
-  # NOTE: Dividing long array of pids into multiple arrays of 100
-  #       pids each so as not to exceed request size limits.
-  def sliced_pids(pids)
-    pids.each_slice(100).to_a
-  end
-
-  def pids_search(query)
-    ActiveFedora::SolrService.instance.conn.post('select', :params=> {:q=>query, :qt=>'standard' , :rows=>100} )
-  end
-
-  def pids_query(pids)
-    ActiveFedora::SolrService.construct_query_for_pids(pids)
   end
 
   def effective_configs

--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -1,0 +1,70 @@
+class Structure
+
+  def initialize(args={})
+    @structure = args[:structure]
+    @id        = args[:id]
+  end
+
+  def default
+    @default ||= Structure::Flat.new(structure: @structure, type: 'default')
+  end
+
+  def images
+    @images ||= Structure::Group.new(structure: @structure, type: 'Images')
+  end
+
+  def files
+    @files ||= Structure::Group.new(structure: @structure, type: 'Documents')
+  end
+
+  def multires_image_file_paths
+    if default.docs.any?
+      docs = default.docs
+    elsif images.docs.any?
+      docs = images.docs
+    else
+      docs = local_id_ordered_components
+    end
+    @multires_image_file_paths ||= docs.map { |doc| doc.multires_image_file_path }.compact
+  end
+
+  def first_multires_image_file_path
+    if default.pids.any?
+      pids = default.pids
+    elsif images.pids.any?
+      pids = images.pids
+    else
+      pids = local_id_ordered_component_pids
+    end
+    doc = SolrDocument.find(pids.first) if pids.present?
+    @first_multires_image_file_path ||= doc.present? ? doc.multires_image_file_path : nil
+  end
+
+  def ordered_component_docs
+   @ordered_component_docs ||= files.docs
+  end
+
+  def derivative_ids
+    @derivative_ids ||= default.local_ids.present? ? default.local_ids : local_id_ordered_component_local_ids
+  end
+
+
+  def local_id_ordered_component_pids
+    local_id_ordered_components.map { |c| c.id } if local_id_ordered_components
+  end
+
+  def local_id_ordered_component_local_ids
+    local_id_ordered_components.map { |c| c.local_id }.compact if local_id_ordered_components
+  end
+
+  def local_id_ordered_components
+    if find_solr_document.components.present?
+      find_solr_document.components.sort { |a,b| a.local_id.to_s <=> b.local_id.to_s }
+    end
+  end
+
+  def find_solr_document
+    @solr_document ||= SolrDocument.find(@id)
+  end
+
+end

--- a/app/models/structure/flat.rb
+++ b/app/models/structure/flat.rb
@@ -1,0 +1,33 @@
+class Structure::Flat < SimpleDelegator
+
+  include Structure::StructureBehavior
+
+
+  def pids
+    order_attribute_value('contents').flatten.map { |component| component['repo_id'] }.compact
+  end
+
+  def labels
+    order_attribute_value('label')
+  end
+
+  def order
+    order_attribute_value('order')
+  end
+
+  def label
+    root_attribute_value('label')
+  end
+
+
+  private
+
+  def order_attribute_value(attribute)
+    root_content(@type).map { |content| content[attribute] }
+  end
+
+  def root_attribute_value(attribute)
+    type_root_node(type)[attribute]
+  end
+
+end

--- a/app/models/structure/group.rb
+++ b/app/models/structure/group.rb
@@ -1,0 +1,37 @@
+class Structure::Group < SimpleDelegator
+
+  include Structure::StructureBehavior
+
+
+  def pids
+    type_group_content('contents').flatten.map { |component| component['repo_id'] }
+  end
+
+  def labels
+    type_group_content('label')
+  end
+
+  def order
+    type_group_content('order')
+  end
+
+  def label
+    attribute_value('label')
+  end
+
+  def id
+    attribute_value('id')
+  end
+
+
+  private
+
+  def type_group_content(attribute)
+    group_content(@type).map { |content| content[attribute] }
+  end
+
+  def attribute_value(attribute)
+    root_content.select { |node| node['type'] == @type }.first[attribute]
+  end
+
+end

--- a/app/models/structure/structure_behavior.rb
+++ b/app/models/structure/structure_behavior.rb
@@ -1,0 +1,91 @@
+module Structure::StructureBehavior
+
+  attr_accessor :structure, :type
+
+  def initialize(args={})
+    @structure = args[:structure]
+    @type      = args[:type]
+    super(docs_list)
+  end
+
+  def docs_list
+    docs.zip(labels, order).map { |h| Hash[doc: h[0], label: h[1], order: h[2]] }
+  end
+
+  def docs
+    ordered_documents(pids) if pids.present? || []
+  end
+
+  def local_ids
+    docs.map { |doc| doc.local_id } if pids.present? || []
+  end
+
+
+  private
+
+  def find_multires_image_file_paths
+    if docs.present?
+      docs.map { |doc| doc.multires_image_file_path }.compact
+    else
+      nil
+    end
+  end
+
+  def find_first_multires_image_file_path
+    if pids.present?
+      SolrDocument.find(pids.first).multires_image_file_path
+    else
+      nil
+    end
+  end
+
+  def ordered_documents(pids)
+    solr_documents = response_to_solr_docs(pids)
+    pids.map{ |pid| solr_documents.find{ |doc| doc["id"] == pid } }
+  end
+
+  def response_to_solr_docs(pids)
+    merged_response_docs(pids).map { |doc| SolrDocument.new(doc) }
+  end
+
+  def merged_response_docs(pids)
+    pids_searches(pids).map { |response| response['response']['docs']}.flatten
+  end
+
+  def pids_searches(pids)
+    pids_queries(pids).map { |query| pids_search(query) }
+  end
+
+  def pids_queries(pids)
+    sliced_pids(pids).map { |pids| pids_query(pids) }
+  end
+
+  # NOTE: Dividing long array of pids into multiple arrays of 100
+  #       pids each so as not to exceed request size limits.
+  def sliced_pids(pids)
+    pids.each_slice(100).to_a
+  end
+
+  def pids_search(query)
+    ActiveFedora::SolrService.instance.conn.post('select', :params=> {:q=>query,
+                                                                      :qt=>'standard',
+                                                                      :rows=>100} )
+  end
+
+  def pids_query(pids)
+    ActiveFedora::SolrService.construct_query_for_pids(pids)
+  end
+
+  def group_content(type='default')
+    root_content.select { |c| c['type'] == type }.map { |t| t['contents'] }.flatten
+  end
+
+  def root_content(type='default')
+    type_root_node(type).present? ? type_root_node(type)['contents'] : {}
+  end
+
+  def type_root_node(type='default')
+    @structure ? @structure[type] : {}
+  end
+
+end

--- a/app/models/thumbnail/multires_collection.rb
+++ b/app/models/thumbnail/multires_collection.rb
@@ -30,7 +30,7 @@ class Thumbnail::MultiresCollection
   private
 
   def collection_multires_image_file_path?
-    collection_multires_image_file_path ? true : false
+    collection_multires_image_file_path.present?
   end
 
   def collection_multires_image_file_path

--- a/app/models/thumbnail/multires_component.rb
+++ b/app/models/thumbnail/multires_component.rb
@@ -26,7 +26,7 @@ class Thumbnail::MultiresComponent
   private
 
   def component_multires_image_file_path?
-    component_multires_image_file_path ? true : false
+    component_multires_image_file_path.present?
   end
 
   def component_multires_image_file_path

--- a/app/models/thumbnail/multires_item.rb
+++ b/app/models/thumbnail/multires_item.rb
@@ -26,7 +26,7 @@ class Thumbnail::MultiresItem
   private
 
   def item_multires_image_file_path?
-    item_multires_image_file_path ? true : false
+    item_multires_image_file_path.present?
   end
 
   def item_multires_image_file_path

--- a/app/views/catalog/_item_options_download_document.html.erb
+++ b/app/views/catalog/_item_options_download_document.html.erb
@@ -1,7 +1,7 @@
 <%# This section appears in the Download menu for items with multi-res image viewer + additional documents %>
 <li class="dropdown-header">Documents <span class="text-muted" style="text-transform: none; font-weight: normal">(may include searchable text)</span></li>
-<% @doc_count = @document.ordered_component_docs("Documents").count %>
-<% @document.ordered_component_docs("Documents").each do |doc| %>
+<% @doc_count = @document.ordered_component_docs.count %>
+<% @document.ordered_component_docs.each do |doc| %>
   <li>
     <%= link_to(download_path(doc)) do %>
         <%= image_tag(default_thumbnail_path(doc), size: "20", alt: doc.content_type) %>

--- a/app/views/digital_collections/_home_showcase_index_portal.html.erb
+++ b/app/views/digital_collections/_home_showcase_index_portal.html.erb
@@ -25,7 +25,7 @@ collections homepage.  %>
         <% if @portal.showcase.documents %>
 
             <% @portal.showcase.documents.sample(1).each_with_index do |doc, index| %>
-              <% if doc.multires_image_file_paths.first %>
+              <% if doc.multires_image_file_paths.first.present? %>
 
                 <div class="col-md-12 col-sm-12 collection-showcase" id="collection-showcase-0" style="background-image: url(<%= iiif_image_path(doc.multires_image_file_paths.first, {:size => '1200,', :region => 'pct:5,5,90,90' }) %>);">
 

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -2,46 +2,5 @@ require 'spec_helper'
 
 RSpec.describe SolrDocument do
 
-  describe "#ordered_component_pids" do
-
-    before { local_id_order_component_pids = double("local_id_order_component_pids") }
-    before { allow(subject).to receive(:local_id_order_component_pids) {nil} }
-
-    context "no indexed struct maps" do
-      it "should return nil" do
-        expect(subject.ordered_component_pids('default')).to be_nil
-      end
-    end
-
-    context "indexed nested struct map" do
-      let(:struct_map) do
-        {"type"=>"default", "divs"=>
-          [{"id"=>"dukechapel_dcrst003606-images", "type"=>"Images", "fptrs"=>[], "divs"=>
-            [{"id"=>"dcrst003606001", "order"=>"1", "fptrs"=>["changeme:1030"], "divs"=>[]},
-             {"id"=>"dcrst003606002", "order"=>"2", "fptrs"=>["changeme:1031"], "divs"=>[]},
-             {"id"=>"dcrst003606003", "order"=>"3", "fptrs"=>["changeme:1032"], "divs"=>[]}]},
-           {"id"=>"dukechapel_dcrst003606-documents", "type"=>"Documents", "fptrs"=>[], "divs"=>
-            [{"id"=>"dcrst003606", "order"=>"1", "fptrs"=>["changeme:1029"], "divs"=>[]}]}
-          ]
-        }
-      end
-
-      before { allow(subject).to receive(:struct_map) { struct_map } }
-
-      context "nested struct map has documents" do
-        let(:expected_result) { ['changeme:1029'] }
-        it "should return the documents portion of the struct map" do
-          expect(subject.ordered_component_pids("Documents")).to match(expected_result)
-        end
-      end
-
-      context "nested struct map is missing requested type" do
-        it "should return nil" do
-          expect(subject.ordered_component_pids("foo")).to match(nil)
-        end
-      end
-
-    end
-  end
 
 end

--- a/spec/models/structure/flat_spec.rb
+++ b/spec/models/structure/flat_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe Structure::Flat do
+
+  let(:structure) { {"default"=>
+    {"type"=>"default", "contents"=>[
+      {"order"=>"1", "contents"=>[{"repo_id"=>"changeme:589"}]},
+      {"order"=>"2", "contents"=>[{"repo_id"=>"changeme:590"}]},
+      {"order"=>"3", "label"=> "Special Thing", "contents"=>[{"repo_id"=>"changeme:591"}]},
+      {"order"=>"4", "contents"=>[{"repo_id"=>"changeme:592"}]}]}
+    }}
+
+  subject { described_class.new({structure: structure, type: 'default'}) }
+
+  its(:pids) { is_expected.to eq(["changeme:589", "changeme:590", "changeme:591", "changeme:592"]) }
+  its(:label) { is_expected.to be_nil }
+  its(:labels) { is_expected.to eq([nil, nil, "Special Thing", nil]) }
+  its(:order) { is_expected.to eq(["1", "2", "3", "4"]) }
+
+end

--- a/spec/models/structure/group_spec.rb
+++ b/spec/models/structure/group_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe Structure::Group do
+
+  let(:structure) {{"default"=>{"type"=>"default", "contents"=>
+    [{"id"=>"dukechapel_dcrst003606-images", "type"=>"Images", "label"=>"Multires Images", "contents"=>[
+      {"order"=>"1", "contents"=>[{"repo_id"=>"changeme:1030"}]},
+      {"order"=>"2", "label"=> "Special Image", "contents"=>[{"repo_id"=>"changeme:1031"}]},
+      {"order"=>"3", "contents"=>[{"repo_id"=>"changeme:1032"}]}]},
+    {"id"=>"dukechapel_dcrst003606-documents", "type"=>"Documents", "contents"=>[
+      {"order"=>"1", "contents"=>[{"repo_id"=>"changeme:1029"}]}]}]}}}
+
+  subject { described_class.new({structure: structure, type: 'Images'}) }
+
+  its(:pids) { is_expected.to eq(["changeme:1030", "changeme:1031", "changeme:1032"]) }
+  its(:label) { is_expected.to eq("Multires Images") }
+  its(:labels) { is_expected.to eq([nil, "Special Image", nil]) }
+  its(:id) { is_expected.to eq("dukechapel_dcrst003606-images") }
+end

--- a/spec/models/structure_spec.rb
+++ b/spec/models/structure_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+RSpec.describe Structure do
+
+  context "Object has default structural metadata" do
+    let(:structure) { {"default"=>
+      {"type"=>"default", "label"=>"Some Stuff", "contents"=>[
+        {"order"=>"1", "contents"=>[{"repo_id"=>"changeme:589"}]},
+        {"order"=>"2", "contents"=>[{"repo_id"=>"changeme:590"}]},
+        {"order"=>"3", "label"=>"This Thing", "contents"=>[{"repo_id"=>"changeme:591"}]},
+        {"order"=>"4", "contents"=>[{"repo_id"=>"changeme:592"}]}]}
+      }}
+
+    subject { described_class.new({structure: structure}) }
+
+    it "should have a list of documents with attributes" do
+      expect(subject.default).to eq([{:doc=>nil, :label=>nil, :order=>"1"},
+                                     {:doc=>nil, :label=>nil, :order=>"2"},
+                                     {:doc=>nil, :label=>"This Thing", :order=>"3"},
+                                     {:doc=>nil, :label=>nil, :order=>"4"}])
+    end
+
+    it "should return an empty array if the structure is absent" do
+      expect(subject.images).to eq([])
+    end
+
+    it "should have some default pids" do
+      expect(subject.default.pids).to eq(["changeme:589", "changeme:590", "changeme:591", "changeme:592"])
+    end
+
+  end
+
+  context "Object has nested structural metadata" do
+    let(:structure) {{"default"=>{"type"=>"default", "contents"=>
+      [{"id"=>"dukechapel_dcrst003606-images", "type"=>"Images", "label"=>"Multires Images", "contents"=>[
+        {"order"=>"1", "contents"=>[{"repo_id"=>"changeme:1030"}]},
+        {"order"=>"2", "label"=>"This Image", "contents"=>[{"repo_id"=>"changeme:1031"}]},
+        {"order"=>"3", "contents"=>[{"repo_id"=>"changeme:1032"}]}]},
+      {"id"=>"dukechapel_dcrst003606-documents", "type"=>"Documents", "contents"=>[
+        {"order"=>"1", "contents"=>[{"repo_id"=>"changeme:1029"}]}]}]}}}
+
+    subject { described_class.new({structure: structure}) }
+
+    it "should have a list of documents with attributes" do
+      expect(subject.images).to eq([{:doc=>nil, :label=>nil, :order=>"1"},
+                                    {:doc=>nil, :label=>"This Image", :order=>"2"},
+                                    {:doc=>nil, :label=>nil, :order=>"3"}])
+    end
+
+    it "should return an empty array if the structure is absent" do
+      expect(subject.default).to eq([])
+    end
+
+    it "should have some pids for images" do
+      expect(subject.images.pids).to eq(["changeme:1030", "changeme:1031", "changeme:1032"])
+    end
+
+    it "should have an id for the images group" do
+      expect(subject.images.id).to eq("dukechapel_dcrst003606-images")
+    end
+
+    it "should have some pids for files" do
+      expect(subject.files.pids).to eq(["changeme:1029"])
+    end
+
+    it "should have an id for the files group" do
+      expect(subject.files.id).to eq("dukechapel_dcrst003606-documents")
+    end
+
+  end
+
+end


### PR DESCRIPTION
This is a first pass at both (1) adding a model and support for the new structural metadata format so that ddr-public can make convenient use of structural metadata and (2) supporting backward compatibility with legacy structural metadata methods to ease the transition/migration.

The new Structures class delegates the following methods to SolrDocument: derivative_ids, multires_image_file_paths, first_multires_image_file_path, and ordered_component_docs. In the future I might decide to deprecate or remove these methods in favor of using the structures model more directly. For now, they provide backwards compatibility and limit the changes needed to the code during the transition.

Going forward, here's how structural metadata may be accessed using the Structure class from a SolrDocument. Currently the flat default structure, and the grouped images and files structures are supported (note that I'm calling this method "files" because "document" is used to refer to solr documents in Blacklight). I can imagine a "nested" type being added in the future to support directory structures.

Sample console interaction with a SolrDocument item with a flat/default structure:

```
> solr_doc = SolrDocument.find('changeme:554')
 => #<SolrDocument id="changeme:554"> 
> solr_doc.structures.default
 => [{:doc=>#<SolrDocument id="changeme:607">, :label=>nil, :order=>"1"}, {:doc=>#<SolrDocument id="changeme:608">, :label=>nil, :order=>"2"}, {:doc=>#<SolrDocument id="changeme:609">, :label=>nil, :order=>"3"}, {:doc=>#<SolrDocument id="changeme:610">, :label=>nil, :order=>"4"}]
```

Sample console interaction with a SolrDocument item with a grouped/images and files structure:

```
> solr_doc = SolrDocument.find('changeme:1021')
 => #<SolrDocument id="changeme:1021"> 
> solr_doc.structures.images
 => [{:doc=>#<SolrDocument id="changeme:1030">, :label=>nil, :order=>"1"}, {:doc=>#<SolrDocument id="changeme:1031">, :label=>nil, :order=>"2"}, {:doc=>#<SolrDocument id="changeme:1032">, :label=>nil, :order=>"3"}] 
> solr_doc.structures.files
 => [{:doc=>#<SolrDocument id="changeme:1029">, :label=>"Sermon", :order=>"1"}]
```

I'll add this note to the jira issue as well.