### PR TITLE
Add configuration for DOI resolver and helper method for linking DOI.

### DIFF
--- a/app/helpers/metadata_display_helper.rb
+++ b/app/helpers/metadata_display_helper.rb
@@ -73,4 +73,8 @@ module MetadataDisplayHelper
     options[:value].map { |value| auto_link(value) }
   end
 
+  def link_to_doi options={}
+    options[:value].map { |value| link_to(value, "#{Ddr::Public.doi_resolver}#{value}") }
+  end
+
 end

--- a/config/initializers/ddr_public.rb
+++ b/config/initializers/ddr_public.rb
@@ -6,4 +6,5 @@ Ddr::Public.configure do |config|
   config.require_authentication = ENV['REQUIRE_AUTHENTICATION']
   config.thumbnails = ENV['THUMBNAILS']
   config.adopt_url = ENV['ADOPT_URL']
+  config.doi_resolver = ENV['DOI_RESOLVER']
 end

--- a/lib/ddr/public/configurable.rb
+++ b/lib/ddr/public/configurable.rb
@@ -21,6 +21,8 @@ module Ddr
 
         mattr_accessor :adopt_url
 
+        mattr_accessor :doi_resolver
+
       end
 
       module ClassMethods

--- a/spec/helpers/metadata_display_helper_spec.rb
+++ b/spec/helpers/metadata_display_helper_spec.rb
@@ -64,4 +64,15 @@ RSpec.describe MetadataDisplayHelper do
     end
   end
 
+  describe "#link_to_doi" do
+    let(:linked_doi) { ["<a href=\"https://dx.doi.org/doi:10.NNNN/NNNNNNNN\">doi:10.NNNN/NNNNNNNN</a>"] }
+    context "field contains a DOI" do
+      before { Ddr::Public.doi_resolver = "https://dx.doi.org/"}
+      let (:metadata_field_values) {["doi:10.NNNN/NNNNNNNN"]}
+      it "should return an array of linked DOI values" do
+        expect(helper.link_to_doi({:value => metadata_field_values})).to match(linked_doi)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Note for deployment: add to local_env.yml

`DOI_RESOLVER: "https://dx.doi.org/"`