### PR TITLE
Add Research Guide link to collection_submast partial for whitelisted URLs

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -219,6 +219,9 @@ module CatalogHelper
     link_to name, url, :class => options[:class], :id => "admin-set"
   end
 
+  def research_guide values=[]
+    values.select { |value| is_research_guide? value }.first if values.present?
+  end
 
   # DPLA Feed document helper
   def source_collection_title document
@@ -280,6 +283,16 @@ module CatalogHelper
     end
     section << '</p>'
     return section
+  end
+
+  def is_research_guide? value
+    research_guides_whitelist.map do |config|
+      value =~ /^https?:\/\/#{Regexp.quote(config).chomp('/')}\/.*/
+    end.compact.present?
+  end
+
+  def research_guides_whitelist
+    String(Ddr::Public.research_guides).split(/,\s?/)
   end
 
 end

--- a/app/views/catalog/_collection_submast.html.erb
+++ b/app/views/catalog/_collection_submast.html.erb
@@ -1,6 +1,6 @@
 <div class="collection-start collection-submast">
   <h1 id="collection-title"><%= document.title %></h1>
-  
+
   <% if document.abstract.present? %>
     <p class="collection-abstract"><%= document.abstract %></p>
   <% end %>
@@ -11,4 +11,5 @@
     <% end %>
   <% end %>
 
+  <%= render partial: "home_showcase_link_list", locals: { document: document } %>
 </div>

--- a/app/views/catalog/_home_showcase_link_list.html.erb
+++ b/app/views/catalog/_home_showcase_link_list.html.erb
@@ -1,0 +1,5 @@
+<% if research_guide = research_guide(document.relation) %>
+  <ul id="showcase-link-list" >
+    <li><%= link_to(I18n.t('ddr.public.showcase_links.research_guide'), research_guide) %></li>
+  </ul>
+<% end %>

--- a/app/views/digital_collections/_home_showcase_link_list.html.erb
+++ b/app/views/digital_collections/_home_showcase_link_list.html.erb
@@ -1,5 +1,0 @@
-<% if document.relation.present? %>
-  <ul id="showcase-link-list" >
-    <li><%= link_to(I18n.t('ddr.public.showcase_links.research_guide'), document.relation.first) %></li>
-  </ul>
-<% end %>

--- a/config/initializers/ddr_public.rb
+++ b/config/initializers/ddr_public.rb
@@ -7,4 +7,5 @@ Ddr::Public.configure do |config|
   config.thumbnails = ENV['THUMBNAILS']
   config.adopt_url = ENV['ADOPT_URL']
   config.doi_resolver = ENV['DOI_RESOLVER']
+  config.research_guides = ENV['RESEARCH_GUIDES']
 end

--- a/lib/ddr/public/configurable.rb
+++ b/lib/ddr/public/configurable.rb
@@ -23,6 +23,8 @@ module Ddr
 
         mattr_accessor :doi_resolver
 
+        mattr_accessor :research_guides
+
       end
 
       module ClassMethods

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -172,4 +172,40 @@ RSpec.describe CatalogHelper do
     end
   end
 
+  describe "#research_guide" do
+    before(:context) { Ddr::Public.research_guides = "guides.library.duke.edu" }
+    context "value is an empty array" do
+      let(:values) { [] }
+      it "should return nil" do
+        expect(helper.research_guide(values)).to be_nil
+      end
+    end
+    context "single value that is not a research guide" do
+      let(:values) { ["ark:/99999/fk4bz6gb1w"] }
+      it "should return nil" do
+        expect(helper.research_guide(values)).to be_nil
+      end
+    end
+    context "single value that is a research guide" do
+      let(:values) { ["http://guides.library.duke.edu/baz"] }
+      it "should return the research guide URL" do
+        expect(helper.research_guide(values)).to eq("http://guides.library.duke.edu/baz")
+      end
+    end
+    context "multiple values with more than one research guide" do
+      let(:values) { ["http://guides.library.duke.edu/baz",
+                      "http://guides.library.duke.edu/foo"] }
+      it "should return the first research guide URL" do
+        expect(helper.research_guide(values)).to eq("http://guides.library.duke.edu/baz")
+      end
+    end
+    context "multiple values without any research guides" do
+      let(:values) { ["ark:/99999/fk4bz6gb1w",
+                      "ark:/99999/hjkfdsieop"] }
+      it "should return nil" do
+        expect(helper.research_guide(values)).to be_nil
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Add line to local_env to configure the list of research guide URLs:

`RESEARCH_GUIDES: "guides.library.duke.edu, library.duke.edu" #comma separate multiple URLs`