### PR TITLE
Exclude components from DC scoped search results

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -99,10 +99,6 @@ class CatalogController < ApplicationController
     config.add_index_field Ddr::Index::Fields::IS_MEMBER_OF_COLLECTION.to_s, helper_method: 'descendant_of', label: 'Collection'
     config.add_index_field Ddr::Index::Fields::COLLECTION_URI.to_s, helper_method: 'descendant_of', label: 'Collection'
 
-    config.default_document_solr_params = {
-      fq: ["#{Ddr::Index::Fields::WORKFLOW_STATE}:published"]
-    }
-
     # partials for show view
     config.show.partials = [:show_header, :show, :show_children, :show_bottom]
 
@@ -255,15 +251,6 @@ class CatalogController < ApplicationController
     config.spell_max = 5
 
   end
-
-
-
-  def exclude_components(solr_parameters, user_parameters)
-      solr_parameters[:fq] ||= []
-      solr_parameters[:fq] << "-#{Ddr::Index::Fields::ACTIVE_FEDORA_MODEL}:Component"
-  end
-
-
 
   def zip_images
     image_list = params[:image_list].split('||')

--- a/app/controllers/digital_collections_controller.rb
+++ b/app/controllers/digital_collections_controller.rb
@@ -16,6 +16,8 @@ class DigitalCollectionsController < CatalogController
   before_action :allow_iframe, only: :show
   before_action :enforce_show_permissions, only: [:show, :media, :feed]
 
+  self.search_params_logic += [:exclude_components]
+
   layout 'digital_collections'
 
   configure_blacklight do |config|

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -15,6 +15,11 @@ class SearchBuilder < Blacklight::Solr::SearchBuilder
     solr_parameters[:fq] << "#{Ddr::Index::Fields::ACTIVE_FEDORA_MODEL}:Item"
   end
 
+  def exclude_components(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] << "-#{Ddr::Index::Fields::ACTIVE_FEDORA_MODEL}:Component"
+  end
+
   def filter_by_parent_collections(solr_parameters)
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] << portal_filters

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe SearchBuilder do
       end
     end
 
+    describe "#exclude_components" do
+      it "returns a filter query that filters components from search results" do
+        expect(subject.exclude_components({}))
+          .to eq(["-active_fedora_model_ssi:Component"])
+      end
+    end
+
     describe "apply_access_controls" do
       before do
         allow(subject).to receive(:policy_role_policies) { ["test-13", "test-45"] }


### PR DESCRIPTION
Because of changes to how Solr queries are generated for fetching thumbnails and components of items for assembling item views, we can now safely filter out components from search results for DC scoped searches. This does not affect searches from /catalog. Also removes some extraneous catalog controller settings that are now handled by search_builder.