### PR TITLE
AV items display thumbnails (with icon overlay) and poster frames, wh…

### DIFF
--- a/app/assets/stylesheets/ddr.scss
+++ b/app/assets/stylesheets/ddr.scss
@@ -680,6 +680,13 @@ image-based items */
         content: "\f115";
       }
     }
+    &.blacklight-video:not(.thumbnail-icon) .document-thumbnail a:first-child, &.blacklight-video:not(.thumbnail-icon) .thumbnail-wrapper a:first-child {
+      &:before {
+        display: block;
+        content: "\f144";
+      }
+    }
+
   }
 }
 

--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -15,6 +15,10 @@ module ThumbnailHelper
     end
   end
 
+  def thumbnail_icon? document
+    thumbnail_path(document).start_with?("ddr-icons/")
+  end
+
   def default_thumbnail_path document
     Thumbnail::Default.new({ document: document }).thumbnail_path
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -15,6 +15,7 @@ class SolrDocument
                  :multires_image_file_paths,
                  :first_multires_image_file_path,
                  :media_paths,
+                 :first_media_doc,
                  :captions_urls,
                  :ordered_component_docs
 

--- a/app/models/structure.rb
+++ b/app/models/structure.rb
@@ -59,6 +59,17 @@ class Structure
     @media_paths ||= docs.map { |doc| doc.stream_url }.compact
   end
 
+  def first_media_doc
+    if default.pids.any?
+      pids = default.pids
+    elsif media.pids.any?
+      pids = media.pids
+    else
+      pids = local_id_ordered_component_pids
+    end
+    @first_media_doc ||= SolrDocument.find(pids.first) if pids.present?
+  end
+
   def captions_urls
     if default.docs.any?
       docs = default.docs

--- a/app/models/thumbnail/audiovisual_item.rb
+++ b/app/models/thumbnail/audiovisual_item.rb
@@ -1,0 +1,29 @@
+class Thumbnail::AudiovisualItem
+
+  attr_accessor :document
+
+  def initialize(args)
+    @document = args.fetch(:document, nil)
+  end
+
+  def has_thumbnail?
+    document.display_format =~ /audio|video/ && repository_generated_thumbnail? ? true : false
+  end
+
+  def thumbnail_path
+    if has_thumbnail?
+      Rails.application.routes.url_helpers.thumbnail_path(first_media_doc_id)
+    end
+  end
+
+  private
+
+  def repository_generated_thumbnail?
+    document.first_media_doc.has_thumbnail?
+  end
+
+  def first_media_doc_id
+    document.first_media_doc.id
+  end
+
+end

--- a/app/views/catalog/_display_jwplayer.html.erb
+++ b/app/views/catalog/_display_jwplayer.html.erb
@@ -38,6 +38,15 @@
               <% if local_assigns[:media_type].present? %>
                 type: "<%= media_type %>",
               <% end %>
+
+              <%# Poster Frame %>
+              <% unless thumbnail_icon?(@document) %>
+                <% if index == 0 %>
+                  image: "<%= thumbnail_path(@document) %>",
+                <%- end -%>
+              <%- end -%>
+
+              <%# Captions %>
               <% if @document.captions_urls.present? %>
                 tracks: [
                   {

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,4 +1,4 @@
-<div class="document col-xs-12 col-sm-6 col-md-4 blacklight-<%= document.display_format or 'no-format' %>">
+<div class="document col-xs-12 col-sm-6 col-md-4 blacklight-<%= document.display_format or 'no-format' %><% if thumbnail_icon?(document) %> thumbnail-icon<% end %>">
   <div class="thumbnail-wrapper">
       <%= render_thumbnail_link(document, "!350,350", document_counter_with_offset(document_counter)) %>
     <div class="caption"><%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>

--- a/spec/models/structure_spec.rb
+++ b/spec/models/structure_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe Structure do
       {"id"=>"dukechapel_dcrau001201-documents", "type"=>"Documents", "contents"=>[
         {"order"=>"1", "label"=>"Transcript", "contents"=>[{"repo_id"=>"changeme:1905"}]}]}]}}}
 
+    let(:av_component_doc) {
+      SolrDocument.new({
+        'id' => 'changeme:1900',
+        'active_fedora_model_ssi' => 'Component'
+        })}
+
     subject { described_class.new({structure: structure}) }
 
     it "has some pids for media objects" do
@@ -72,6 +78,12 @@ RSpec.describe Structure do
     it "has an id for the media group" do
       expect(subject.media.id).to eq("dukechapel_dcrau001201-media")
     end
+
+    it "finds the first media object (e.g., for av thumb/poster)" do
+      allow(SolrDocument).to receive(:find).with("changeme:1900") { av_component_doc }
+      expect(subject.first_media_doc).to eq(av_component_doc)
+    end
+
   end
 
   context "Object has directory structural metadata" do

--- a/spec/models/thumbnail/audiovisual_item_spec.rb
+++ b/spec/models/thumbnail/audiovisual_item_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe Thumbnail::AudiovisualItem do
+
+  let(:av_component_doc) {
+    SolrDocument.new({
+      'id' => 'changeme:111',
+      'active_fedora_model_ssi' => 'Component'
+      })}
+
+  describe "audiovisual item thumbnail" do
+
+    it "doesn't have display format set to audio or video" do
+      document = double("Document")
+      allow(document).to receive(:display_format) { "image" }
+      avthumb = Thumbnail::AudiovisualItem.new({ document: document })
+      expect(avthumb.has_thumbnail?).to eq false
+    end
+
+    it "has video display format and a media component with a repo thumb" do
+      document = double("Document")
+      allow(document).to receive(:display_format) { "video" }
+      allow(document).to receive(:first_media_doc) { av_component_doc }
+      allow(av_component_doc).to receive(:has_thumbnail?) { true }
+      avthumb = Thumbnail::AudiovisualItem.new({document: document})
+      expect(avthumb.has_thumbnail?).to eq true
+    end
+
+    it "has video display format but media component lacks a repo thumb" do
+      document = double("Document")
+      allow(document).to receive(:display_format) { "video" }
+      allow(document).to receive(:first_media_doc) { av_component_doc }
+      allow(av_component_doc).to receive(:has_thumbnail?) { false }
+      avthumb = Thumbnail::AudiovisualItem.new({document: document})
+      expect(avthumb.has_thumbnail?).to eq false
+    end
+
+    it "has audio or video display format and its first component has a repo thumb" do
+      document = double("Document")
+      allow(document).to receive(:first_media_doc) { av_component_doc }
+      avthumb = Thumbnail::AudiovisualItem.new({document: document})
+      allow(avthumb).to receive(:has_thumbnail?) { true }
+      expect(avthumb.thumbnail_path).to eq '/thumbnail/changeme:111'
+    end
+
+  end
+
+end


### PR DESCRIPTION
…en components have repo thumbs. Closes DDR-1187.

<img width="819" alt="screen shot 2017-08-16 at 9 57 14 am" src="https://user-images.githubusercontent.com/3933756/29366952-5bb049a8-8269-11e7-8043-3078aaf372d9.png">
<img width="872" alt="screen shot 2017-08-16 at 9 56 53 am" src="https://user-images.githubusercontent.com/3933756/29366951-5bad685a-8269-11e7-8c23-462dd61f5832.png">
